### PR TITLE
OCL: Added sanity data for HoughLines performance test

### DIFF
--- a/testdata/perf/imgproc.xml
+++ b/testdata/perf/imgproc.xml
@@ -89980,4 +89980,178 @@
       <y>971</y>
       <cn>2</cn>
       <val>60.</val></rng2></dst></Size_CvtMode_cvtColor8u--cvtColor8u---1920x1080--CX_RGBA2Luv->
+ <!-- resumed -->
+
+<OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--0-1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 9.99500046e+001 1.57079637e+000
+        1.99949997e+002 0. 1.99949997e+002 1.57079637e+000
+        3.99950012e+002 0. 3.99950012e+002 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--0-1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--0-1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 1.99949997e+002 0. 3.99950012e+002 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--0-1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 100. 1.57079637e+000 200. 0. 200. 1.57079637e+000 400.
+        0. 400. 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 200. 0. 400. 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---640x480--1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--0-1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 9.99500046e+001 1.57079637e+000
+        1.99949997e+002 0. 1.99949997e+002 1.57079637e+000
+        3.99950012e+002 0. 3.99950012e+002 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--0-1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--0-1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 1.99949997e+002 0. 3.99950012e+002 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--0-1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 100. 1.57079637e+000 200. 0. 200. 1.57079637e+000 400.
+        0. 400. 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 200. 0. 400. 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1280x720--1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--0-1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 9.99500046e+001 1.57079637e+000
+        1.99949997e+002 0. 1.99949997e+002 1.57079637e+000
+        3.99950012e+002 0. 3.99950012e+002 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--0-1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--0-1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 1.99949997e+002 0. 3.99950012e+002 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--0-1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 100. 1.57079637e+000 200. 0. 200. 1.57079637e+000 400.
+        0. 400. 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 200. 0. 400. 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---1920x1080--1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--0-1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 9.99500046e+001 1.57079637e+000
+        1.99949997e+002 0. 1.99949997e+002 1.57079637e+000
+        3.99950012e+002 0. 3.99950012e+002 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--0-1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--0-1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        9.99500046e+001 0. 1.99949997e+002 0. 3.99950012e+002 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--0-1--0-1->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--1--0-0174533->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>6</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 100. 1.57079637e+000 200. 0. 200. 1.57079637e+000 400.
+        0. 400. 1.57079637e+000</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--1--0-0174533->
+<OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--1--0-1->
+  <result>
+    <kind>65536</kind>
+    <type>13</type>
+    <val type_id="opencv-matrix">
+      <rows>3</rows>
+      <cols>1</cols>
+      <dt>"2f"</dt>
+      <data>
+        100. 0. 200. 0. 400. 0.</data></val></result></OCL_HoughLinesFixture_HoughLines--HoughLines---3840x2160--1--0-1->
 </opencv_storage>


### PR DESCRIPTION
Sanity data for: Itseez/opencv#3278
