### PR TITLE
stereomatching: add validation of min disparity affect on valid ROI

### DIFF
--- a/testdata/cv/stereomatching/algorithms/stereobm_params.xml
+++ b/testdata/cv/stereomatching/algorithms/stereobm_params.xml
@@ -1,14 +1,21 @@
 <?xml version="1.0"?>
 <opencv_storage>
 <params>
-	<!-- caseName, datasetName, numDisp, winSize -->
-	case_barn2 barn2 "16" "19"
-	case_bull bull "16" "39"
-	case_cones cones "64" "11"
-	case_poster poster "48" "9"
-	case_sawtooth sawtooth "16" "13"
-	case_teddy teddy "48" "15"
-	case_tsukuba tsukuba "16" "21"
-	case_venus venus "32" "43"
+	<!-- caseName, datasetName, numDisp, minDisp, winSize -->
+	case_barn2 barn2 "16" "0" "19"
+	case_bull bull "16" "0" "39"
+	case_cones cones "64" "0" "11"
+	case_cones_p16 cones "48" "16" "11"
+	case_cones_p32 cones "32" "32" "11"
+	case_cones_m16 cones "80" "-16" "11"
+	case_poster poster "48" "0" "9"
+	case_poster_p16 poster "32" "16" "9"
+	case_poster_m16 poster "64" "-16" "9"
+	case_sawtooth sawtooth "16" "0" "13"
+	case_teddy teddy "48" "0" "15"
+	case_teddy_p16 teddy "32" "16" "15"
+	case_teddy_m16 teddy "64" "-16" "15"
+	case_tsukuba tsukuba "16" "0" "21"
+	case_venus venus "32" "0" "43"
 </params>
 </opencv_storage>

--- a/testdata/cv/stereomatching/algorithms/stereobm_res.xml
+++ b/testdata/cv/stereomatching/algorithms/stereobm_res.xml
@@ -3,122 +3,302 @@
 <stereo_matching>
   <case_barn2>
     <!-- RMS -->
-    <borderedAllRMS>3.2144327163696289e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.9689066410064697e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>9.0024099349975586e+00</borderedOcclRMS>
-    <borderedTexturedRMS>3.0065546035766602e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.9337391853332520e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>5.6972937583923340e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>3.2253861427307129e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.9760103225708008e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>9.0792274475097656e+00</borderedOcclRMS>
+    <borderedTexturedRMS>3.0014173984527588e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.9523718357086182e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>5.7398724555969238e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.2365380674600601e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.0577023029327393e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.5660561323165894e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>9.3704164028167725e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.1690396815538406e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>4.4223231077194214e-01</borderedDepthDiscontBadPxlsFraction></case_barn2>
+    <borderedAllBadPxlsFraction>1.2646442651748657e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.0856527835130692e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.6014142036437988e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>9.5142222940921783e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.2095115333795547e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.5336258411407471e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>24</roiX>
+    <roiY>9</roiY>
+    <roiWidth>397</roiWidth>
+    <roiHeight>363</roiHeight></case_barn2>
   <case_bull>
     <!-- RMS -->
-    <borderedAllRMS>2.6062276363372803e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.6070611476898193e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>2.1717951297760010e+00</borderedOcclRMS>
-    <borderedTexturedRMS>3.1280007362365723e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.1046974658966064e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>4.7128300666809082e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>2.5480229854583740e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.5487673282623291e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>2.1633861064910889e+00</borderedOcclRMS>
+    <borderedTexturedRMS>3.0429389476776123e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.0753195285797119e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>4.6195740699768066e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.0362771153450012e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.0179582983255386e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.7879856824874878e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.0288458317518234e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.0093323886394501e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>4.8397904634475708e-01</borderedDepthDiscontBadPxlsFraction></case_bull>
+    <borderedAllBadPxlsFraction>1.0201867669820786e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.0014644265174866e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.9646645784378052e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.0265033692121506e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>9.8162680864334106e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.7623035311698914e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>34</roiX>
+    <roiY>19</roiY>
+    <roiWidth>380</roiWidth>
+    <roiHeight>343</roiHeight></case_bull>
   <case_cones>
     <!-- RMS -->
-    <borderedAllRMS>1.6140068054199219e+01</borderedAllRMS>
-    <borderedNoOcclRMS>1.2398996353149414e+01</borderedNoOcclRMS>
-    <borderedOcclRMS>3.5002265930175781e+01</borderedOcclRMS>
-    <borderedTexturedRMS>1.1403450012207031e+01</borderedTexturedRMS>
-    <borderedTexturelessRMS>1.4676580429077148e+01</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>1.7508829116821289e+01</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.6151809692382812e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.2428104400634766e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>3.4961860656738281e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.1443375587463379e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.4684398651123047e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.7560453414916992e+01</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.5318911671638489e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.7293582856655121e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.7656565904617310e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.7243999242782593e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.7422622442245483e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>3.6357000470161438e-01</borderedDepthDiscontBadPxlsFraction></case_cones>
+    <borderedAllBadPxlsFraction>2.5528478622436523e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.7513830959796906e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.7772043943405151e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.7473959922790527e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.7617590725421906e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>3.7099435925483704e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>68</roiX>
+    <roiY>5</roiY>
+    <roiWidth>377</roiWidth>
+    <roiHeight>365</roiHeight></case_cones>
+  <case_cones_p16>
+    <!-- RMS -->
+    <borderedAllRMS>1.5615251541137695e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.1953493118286133e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>3.4001079559326172e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.0944602966308594e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.4247986793518066e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.6743787765502930e+01</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>2.5244548916816711e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.7228186130523682e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.7513926029205322e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.7124335467815399e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.7498442530632019e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>3.6271336674690247e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>68</roiX>
+    <roiY>5</roiY>
+    <roiWidth>377</roiWidth>
+    <roiHeight>365</roiHeight></case_cones_p16>
+  <case_cones_p32>
+    <!-- RMS -->
+    <borderedAllRMS>2.0776138305664062e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.8657592773437500e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>3.4431545257568359e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.7844285964965820e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.0624328613281250e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>2.1712009429931641e+01</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>5.7033634185791016e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>5.2446025609970093e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8193180561065674e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>5.1831889152526855e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>5.4044246673583984e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>6.5803664922714233e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>68</roiX>
+    <roiY>5</roiY>
+    <roiWidth>377</roiWidth>
+    <roiHeight>365</roiHeight></case_cones_p32>
+  <case_cones_m16>
+    <!-- RMS -->
+    <borderedAllRMS>1.6309083938598633e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.2856628417968750e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>3.4288265228271484e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.2114905357360840e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.4611428260803223e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.8159482955932617e+01</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>2.6635795831680298e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.8740603327751160e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.7792416810989380e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.8840202689170837e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.8481411039829254e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>3.8907924294471741e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>68</roiX>
+    <roiY>5</roiY>
+    <roiWidth>377</roiWidth>
+    <roiHeight>365</roiHeight></case_cones_m16>
   <case_poster>
     <!-- RMS -->
-    <borderedAllRMS>4.7389020919799805e+00</borderedAllRMS>
-    <borderedNoOcclRMS>4.5418138504028320e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>9.0001211166381836e+00</borderedOcclRMS>
-    <borderedTexturedRMS>3.5093963146209717e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>5.9692144393920898e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>4.9760332107543945e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>4.7719388008117676e+00</borderedAllRMS>
+    <borderedNoOcclRMS>4.5714673995971680e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>9.0952548980712891e+00</borderedOcclRMS>
+    <borderedTexturedRMS>3.6051354408264160e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>5.9295949935913086e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>5.0719881057739258e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.1746489405632019e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.9409780204296112e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.6538126468658447e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.1876342445611954e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>3.3007547259330750e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.4409590661525726e-01</borderedDepthDiscontBadPxlsFraction></case_poster>
+    <borderedAllBadPxlsFraction>2.1742506325244904e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.9400195777416229e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.6713411808013916e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.2136975675821304e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>3.2510223984718323e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.4977464973926544e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>51</roiX>
+    <roiY>4</roiY>
+    <roiWidth>380</roiWidth>
+    <roiHeight>375</roiHeight></case_poster>
+  <case_poster_p16>
+    <!-- RMS -->
+    <borderedAllRMS>1.1833208084106445e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.1853628158569336e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>1.1159900665283203e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.1851127624511719e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.1858140945434570e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.1940442085266113e+01</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>7.5948750972747803e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>7.5197327136993408e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>1.</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>6.9093209505081177e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>8.6215174198150635e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>7.2579771280288696e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>51</roiX>
+    <roiY>4</roiY>
+    <roiWidth>380</roiWidth>
+    <roiHeight>375</roiHeight></case_poster_p16>
+  <case_poster_m16>
+    <!-- RMS -->
+    <borderedAllRMS>4.9212641716003418e+00</borderedAllRMS>
+    <borderedNoOcclRMS>4.7629761695861816e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>8.5605335235595703e+00</borderedOcclRMS>
+    <borderedTexturedRMS>4.0029826164245605e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>5.8915967941284180e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>5.1675333976745605e+00</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>2.3897241055965424e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>2.1613352000713348e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.6998250484466553e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.3842257857322693e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>3.5640084743499756e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.6599964499473572e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>51</roiX>
+    <roiY>4</roiY>
+    <roiWidth>380</roiWidth>
+    <roiHeight>375</roiHeight></case_poster_m16>
   <case_sawtooth>
     <!-- RMS -->
-    <borderedAllRMS>6.1118903160095215e+00</borderedAllRMS>
-    <borderedNoOcclRMS>5.9747385978698730e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>9.8244810104370117e+00</borderedOcclRMS>
-    <borderedTexturedRMS>5.7268137931823730e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>6.3689489364624023e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.6281979084014893e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>6.0209369659423828e+00</borderedAllRMS>
+    <borderedNoOcclRMS>5.8783531188964844e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>9.8390560150146484e+00</borderedOcclRMS>
+    <borderedTexturedRMS>5.6303768157958984e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>6.2723093032836914e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.6215057373046875e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.9893316924571991e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.7705444991588593e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.7981292009353638e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.6939896345138550e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.8989491462707520e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.6451182365417480e-01</borderedDepthDiscontBadPxlsFraction></case_sawtooth>
+    <borderedAllBadPxlsFraction>1.9887277483940125e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.7706134915351868e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.7735106945037842e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.6869433224201202e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.9109526276588440e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.6643931865692139e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>21</roiX>
+    <roiY>6</roiY>
+    <roiWidth>407</roiWidth>
+    <roiHeight>368</roiHeight></case_sawtooth>
   <case_teddy>
     <!-- RMS -->
-    <borderedAllRMS>1.4281317710876465e+01</borderedAllRMS>
-    <borderedNoOcclRMS>1.1736121177673340e+01</borderedNoOcclRMS>
-    <borderedOcclRMS>2.9781908035278320e+01</borderedOcclRMS>
-    <borderedTexturedRMS>1.1007680892944336e+01</borderedTexturedRMS>
-    <borderedTexturelessRMS>1.2448151588439941e+01</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>1.6359529495239258e+01</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.4248176574707031e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.1700111389160156e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>2.9747314453125000e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.0972145080566406e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.2411572456359863e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.6307731628417969e+01</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.7192699909210205e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>2.0191769301891327e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.9054229259490967e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>2.0456841588020325e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.9916258752346039e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>4.2352175712585449e-01</borderedDepthDiscontBadPxlsFraction></case_teddy>
+    <borderedAllBadPxlsFraction>2.7434545755386353e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>2.0445647835731506e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.9176263809204102e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>2.0716740190982819e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>2.0163880288600922e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.2909938097000122e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>54</roiX>
+    <roiY>7</roiY>
+    <roiWidth>389</roiWidth>
+    <roiHeight>361</roiHeight></case_teddy>
+  <case_teddy_p16>
+    <!-- RMS -->
+    <borderedAllRMS>1.4115718841552734e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.1716758728027344e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>2.8956106185913086e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.1413619041442871e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.2023736953735352e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.5675322532653809e+01</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>2.9903259873390198e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>2.3159568011760712e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.9153381586074829e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>2.6098066568374634e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>2.0105351507663727e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.2752531170845032e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>54</roiX>
+    <roiY>7</roiY>
+    <roiWidth>389</roiWidth>
+    <roiHeight>361</roiHeight></case_teddy_p16>
+  <case_teddy_m16>
+    <!-- RMS -->
+    <borderedAllRMS>1.4407378196716309e+01</borderedAllRMS>
+    <borderedNoOcclRMS>1.2057464599609375e+01</borderedNoOcclRMS>
+    <borderedOcclRMS>2.9126796722412109e+01</borderedOcclRMS>
+    <borderedTexturedRMS>1.1305538177490234e+01</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.2792243003845215e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.7016613006591797e+01</borderedDepthDiscontRMS>
+    <!-- BadPxlsFraction -->
+    <borderedAllBadPxlsFraction>2.8524532914161682e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>2.1629676222801208e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.9275416135787964e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>2.1824193000793457e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>2.1427500247955322e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.4494250416755676e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>54</roiX>
+    <roiY>7</roiY>
+    <roiWidth>389</roiWidth>
+    <roiHeight>361</roiHeight></case_teddy_m16>
   <case_tsukuba>
     <!-- RMS -->
-    <borderedAllRMS>2.6333224773406982e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.5312962532043457e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>5.1777315139770508e+00</borderedOcclRMS>
-    <borderedTexturedRMS>2.6008524894714355e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.4486551284790039e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>5.1582503318786621e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>2.6483373641967773e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.5463445186614990e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>5.1958971023559570e+00</borderedOcclRMS>
+    <borderedTexturedRMS>2.5948498249053955e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.4892506599426270e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>5.1761937141418457e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.4067916572093964e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.2637099623680115e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>6.8035316467285156e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.2330324202775955e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.2990777194499969e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>4.1344586014747620e-01</borderedDepthDiscontBadPxlsFraction></case_tsukuba>
+    <borderedAllBadPxlsFraction>1.4127212762832642e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.2675726413726807e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>6.8874168395996094e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.2474589049816132e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.2907615303993225e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.2136827111244202e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>25</roiX>
+    <roiY>10</roiY>
+    <roiWidth>349</roiWidth>
+    <roiHeight>268</roiHeight></case_tsukuba>
   <case_venus>
     <!-- RMS -->
-    <borderedAllRMS>3.8208043575286865e+00</borderedAllRMS>
-    <borderedNoOcclRMS>3.8105592727661133e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>4.5990791320800781e+00</borderedOcclRMS>
-    <borderedTexturedRMS>3.9956395626068115e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.6458954811096191e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>4.3752012252807617e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>3.8138930797576904e+00</borderedAllRMS>
+    <borderedNoOcclRMS>3.8033421039581299e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>4.6132268905639648e+00</borderedOcclRMS>
+    <borderedTexturedRMS>3.9910359382629395e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.6362276077270508e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>4.3007078170776367e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.5725806355476379e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.4799085259437561e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.3401014804840088e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.1592459678649902e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.7524155974388123e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>4.1620603203773499e-01</borderedDepthDiscontBadPxlsFraction></case_venus></stereo_matching>
+    <borderedAllBadPxlsFraction>1.5757226943969727e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.4835423231124878e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.3020302057266235e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.1594107002019882e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.7589972913265228e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>4.1319096088409424e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>52</roiX>
+    <roiY>21</roiY>
+    <roiWidth>361</roiWidth>
+    <roiHeight>341</roiHeight></case_venus></stereo_matching>
 </opencv_storage>

--- a/testdata/cv/stereomatching/algorithms/stereosgbm_params.xml
+++ b/testdata/cv/stereomatching/algorithms/stereosgbm_params.xml
@@ -15,8 +15,8 @@
 	case_teddy_0 teddy "48" "3" "0"
 	case_teddy_1 teddy "48" "3" "1"
 	case_tsukuba_0 tsukuba "16" "1" "0"
-	case_tsukuba_1 tsukuba "16" "1" "0"
+	case_tsukuba_1 tsukuba "16" "1" "1"
 	case_venus_0 venus "32" "3" "0"
-	case_venus_1 venus "32" "3" "0"
+	case_venus_1 venus "32" "3" "1"
 </params>
 </opencv_storage>

--- a/testdata/cv/stereomatching/algorithms/stereosgbm_res.xml
+++ b/testdata/cv/stereomatching/algorithms/stereosgbm_res.xml
@@ -3,242 +3,322 @@
 <stereo_matching>
   <case_barn2_0>
     <!-- RMS -->
-    <borderedAllRMS>2.9965159893035889e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.7913968563079834e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>8.0171709060668945e+00</borderedOcclRMS>
-    <borderedTexturedRMS>2.1012992858886719e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.3026416301727295e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.3091175556182861e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>2.9053575992584229e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.6770668029785156e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>8.2339944839477539e+00</borderedOcclRMS>
+    <borderedTexturedRMS>2.0894150733947754e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.1227049827575684e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.2846446037292480e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.5230052173137665e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.3421763479709625e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.9453550577163696e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>6.6179640591144562e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.9699844717979431e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.1406175196170807e-01</borderedDepthDiscontBadPxlsFraction></case_barn2_0>
+    <borderedAllBadPxlsFraction>1.5176001191139221e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.3367933034896851e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.9389261007308960e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>6.6093362867832184e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.9604304432868958e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.1398337185382843e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>32</roiX>
+    <roiY>1</roiY>
+    <roiWidth>397</roiWidth>
+    <roiHeight>379</roiHeight></case_barn2_0>
   <case_barn2_1>
     <!-- RMS -->
-    <borderedAllRMS>2.9830119609832764e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.7657139301300049e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>8.1902914047241211e+00</borderedOcclRMS>
-    <borderedTexturedRMS>2.1049506664276123e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.2586576938629150e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.4364361763000488e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>2.8747549057006836e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.6455760002136230e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>8.1969509124755859e+00</borderedOcclRMS>
+    <borderedTexturedRMS>2.0794649124145508e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.0768952369689941e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.4145896434783936e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.4848996698856354e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.3025625050067902e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.9774992465972900e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>6.6424116492271423e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.8915618956089020e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.3216804862022400e-01</borderedDepthDiscontBadPxlsFraction></case_barn2_1>
+    <borderedAllBadPxlsFraction>1.4708465337753296e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.2883457541465759e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.9710702896118164e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>6.5805748105049133e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.8699327111244202e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.3060040175914764e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>32</roiX>
+    <roiY>1</roiY>
+    <roiWidth>397</roiWidth>
+    <roiHeight>379</roiHeight></case_barn2_1>
   <case_bull_0>
     <!-- RMS -->
-    <borderedAllRMS>2.6672914028167725e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.4570498466491699e+00</borderedNoOcclRMS>
+    <borderedAllRMS>2.6324415206909180e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.4189500808715820e+00</borderedNoOcclRMS>
     <borderedOcclRMS>1.3823496818542480e+01</borderedOcclRMS>
-    <borderedTexturedRMS>2.8043155670166016e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.1387035846710205e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.4524977207183838e+00</borderedDepthDiscontRMS>
+    <borderedTexturedRMS>2.8044145107269287e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.0589013099670410e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.4497253894805908e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>8.4765881299972534e-02</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>7.9473771154880524e-02</borderedNoOcclBadPxlsFraction>
+    <borderedAllBadPxlsFraction>8.4383569657802582e-02</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>7.9089224338531494e-02</borderedNoOcclBadPxlsFraction>
     <borderedOcclBadPxlsFraction>9.8847925662994385e-01</borderedOcclBadPxlsFraction>
     <borderedTexturedBadPxlsFraction>8.1396408379077911e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>7.7934227883815765e-02</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.9838547110557556e-01</borderedDepthDiscontBadPxlsFraction></case_bull_0>
+    <borderedTexturelessBadPxlsFraction>7.7241748571395874e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.9838547110557556e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>34</roiX>
+    <roiY>3</roiY>
+    <roiWidth>396</roiWidth>
+    <roiHeight>375</roiHeight></case_bull_0>
   <case_bull_1>
     <!-- RMS -->
-    <borderedAllRMS>2.5991113185882568e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.3821535110473633e+00</borderedNoOcclRMS>
+    <borderedAllRMS>2.5868144035339355e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.3686518669128418e+00</borderedNoOcclRMS>
     <borderedOcclRMS>1.3831359863281250e+01</borderedOcclRMS>
-    <borderedTexturedRMS>2.7518110275268555e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.0383787155151367e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.8347580432891846e+00</borderedDepthDiscontRMS>
+    <borderedTexturedRMS>2.7432312965393066e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.0192158222198486e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.8219957351684570e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>7.9956799745559692e-02</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>7.4596054852008820e-02</borderedNoOcclBadPxlsFraction>
+    <borderedAllBadPxlsFraction>7.9802535474300385e-02</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>7.4440881609916687e-02</borderedNoOcclBadPxlsFraction>
     <borderedOcclBadPxlsFraction>9.9539172649383545e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>8.0546788871288300e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>6.9831013679504395e-02</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>3.0576041340827942e-01</borderedDepthDiscontBadPxlsFraction></case_bull_1>
+    <borderedTexturedBadPxlsFraction>8.0379903316497803e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>6.9685228168964386e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>3.0556109547615051e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>34</roiX>
+    <roiY>3</roiY>
+    <roiWidth>396</roiWidth>
+    <roiHeight>375</roiHeight></case_bull_1>
   <case_cones_0>
     <!-- RMS -->
-    <borderedAllRMS>1.4496342658996582e+01</borderedAllRMS>
-    <borderedNoOcclRMS>1.0156044006347656e+01</borderedNoOcclRMS>
-    <borderedOcclRMS>3.4333236694335938e+01</borderedOcclRMS>
-    <borderedTexturedRMS>8.9537706375122070e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>1.2764611244201660e+01</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>1.2214662551879883e+01</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.4276436805725098e+01</borderedAllRMS>
+    <borderedNoOcclRMS>9.9607954025268555e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>3.3922489166259766e+01</borderedOcclRMS>
+    <borderedTexturedRMS>8.7162590026855469e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.2637552261352539e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.1662704467773438e+01</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.2531013190746307e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.4148475229740143e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.8254311084747314e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.3815385103225708e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.5015299618244171e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.7333587408065796e-01</borderedDepthDiscontBadPxlsFraction></case_cones_0>
+    <borderedAllBadPxlsFraction>2.2494508326053619e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.4113897085189819e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8199975490570068e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.3758155703544617e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.5039670467376709e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.7225711941719055e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>65</roiX>
+    <roiY>2</roiY>
+    <roiWidth>383</roiWidth>
+    <roiHeight>371</roiHeight></case_cones_0>
   <case_cones_1>
     <!-- RMS -->
-    <borderedAllRMS>1.4518835067749023e+01</borderedAllRMS>
-    <borderedNoOcclRMS>1.0196671485900879e+01</borderedNoOcclRMS>
-    <borderedOcclRMS>3.4322090148925781e+01</borderedOcclRMS>
-    <borderedTexturedRMS>8.9673328399658203e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>1.2856185913085938e+01</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>1.2161293029785156e+01</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.4212940216064453e+01</borderedAllRMS>
+    <borderedNoOcclRMS>9.8690538406372070e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>3.3899070739746094e+01</borderedOcclRMS>
+    <borderedTexturedRMS>8.6216440200805664e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.2546838760375977e+01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>1.1629960060119629e+01</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.2708806395530701e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.4327380061149597e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.8444503545761108e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.4059914648532867e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.5023423731327057e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.7796813845634460e-01</borderedDepthDiscontBadPxlsFraction></case_cones_1>
+    <borderedAllBadPxlsFraction>2.2533041238784790e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.4135695993900299e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8403751850128174e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.3869494199752808e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.4828455448150635e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.7698457241058350e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>65</roiX>
+    <roiY>2</roiY>
+    <roiWidth>383</roiWidth>
+    <roiHeight>371</roiHeight></case_cones_1>
   <case_poster_0>
     <!-- RMS -->
-    <borderedAllRMS>2.9647486209869385e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.6094138622283936e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>8.4962482452392578e+00</borderedOcclRMS>
-    <borderedTexturedRMS>1.8225036859512329e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.6199417114257812e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.2358210086822510e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>2.8916738033294678e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.5229487419128418e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>8.5008478164672852e+00</borderedOcclRMS>
+    <borderedTexturedRMS>1.7968229055404663e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.4679927825927734e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.1982648372650146e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.3815924525260925e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.1230071634054184e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.6581947803497314e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>5.6360501796007156e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>2.1327213943004608e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>1.6017666459083557e-01</borderedDepthDiscontBadPxlsFraction></case_poster_0>
+    <borderedAllBadPxlsFraction>1.3740250468254089e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.1153401434421539e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.6538126468658447e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>5.6371141225099564e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>2.1110236644744873e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>1.5936541557312012e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>33</roiX>
+    <roiY>2</roiY>
+    <roiWidth>400</roiWidth>
+    <roiHeight>379</roiHeight></case_poster_0>
   <case_poster_1>
     <!-- RMS -->
-    <borderedAllRMS>2.9616200923919678e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.6015021800994873e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>8.5377893447875977e+00</borderedOcclRMS>
-    <borderedTexturedRMS>1.7865190505981445e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.6363098621368408e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.4036531448364258e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>2.8787150382995605e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.5067183971405029e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>8.5093526840209961e+00</borderedOcclRMS>
+    <borderedTexturedRMS>1.7650070190429688e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.4644680023193359e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.3919942378997803e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.3733612000942230e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.1117120087146759e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.7480279207229614e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>5.6073274463415146e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>2.1062232553958893e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>1.8568594753742218e-01</borderedDepthDiscontBadPxlsFraction></case_poster_1>
+    <borderedAllBadPxlsFraction>1.3594211637973785e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.0980209708213806e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.7261172533035278e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>5.5743493139743805e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>2.0737725496292114e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>1.8550567328929901e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>33</roiX>
+    <roiY>2</roiY>
+    <roiWidth>400</roiWidth>
+    <roiHeight>379</roiHeight></case_poster_1>
   <case_sawtooth_0>
     <!-- RMS -->
-    <borderedAllRMS>3.3119509220123291e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.9521915912628174e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>9.5604572296142578e+00</borderedOcclRMS>
-    <borderedTexturedRMS>3.2275133132934570e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.4210910797119141e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.3165266513824463e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>3.3000922203063965e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.9296362400054932e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>9.6571426391601562e+00</borderedOcclRMS>
+    <borderedTexturedRMS>3.2130870819091797e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.3795666694641113e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.2734408378601074e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.0845410078763962e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>8.4005847573280334e-02</borderedNoOcclBadPxlsFraction>
+    <borderedAllBadPxlsFraction>1.0814546048641205e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>8.3688557147979736e-02</borderedNoOcclBadPxlsFraction>
     <borderedOcclBadPxlsFraction>9.8104381561279297e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>8.6615212261676788e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>7.9629182815551758e-02</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>1.8696714937686920e-01</borderedDepthDiscontBadPxlsFraction></case_sawtooth_0>
+    <borderedTexturedBadPxlsFraction>8.6472079157829285e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>7.9019777476787567e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>1.8474312126636505e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>32</roiX>
+    <roiY>1</roiY>
+    <roiWidth>401</roiWidth>
+    <roiHeight>378</roiHeight></case_sawtooth_0>
   <case_sawtooth_1>
     <!-- RMS -->
-    <borderedAllRMS>3.3013341426849365e+00</borderedAllRMS>
-    <borderedNoOcclRMS>2.9338188171386719e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>9.6273469924926758e+00</borderedOcclRMS>
-    <borderedTexturedRMS>3.2152044773101807e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>2.3885490894317627e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.3725454807281494e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>3.2782785892486572e+00</borderedAllRMS>
+    <borderedNoOcclRMS>2.8999884128570557e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>9.7038087844848633e+00</borderedOcclRMS>
+    <borderedTexturedRMS>3.1806466579437256e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>2.3553142547607422e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.3503036499023438e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.0708534717559814e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>8.2460790872573853e-02</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.8596751689910889e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>8.6637228727340698e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>7.5455665588378906e-02</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>1.9593742489814758e-01</borderedDepthDiscontBadPxlsFraction></case_sawtooth_1>
+    <borderedAllBadPxlsFraction>1.0633386671543121e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>8.1695154309272766e-02</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8572134971618652e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>8.6053706705570221e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>7.4384585022926331e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>1.9519607722759247e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>32</roiX>
+    <roiY>1</roiY>
+    <roiWidth>401</roiWidth>
+    <roiHeight>378</roiHeight></case_sawtooth_1>
   <case_teddy_0>
     <!-- RMS -->
-    <borderedAllRMS>1.1820409774780273e+01</borderedAllRMS>
-    <borderedNoOcclRMS>8.3108730316162109e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>2.9530620574951172e+01</borderedOcclRMS>
-    <borderedTexturedRMS>7.6741085052490234e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>8.9246892929077148e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>9.6189661026000977e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.1425792694091797e+01</borderedAllRMS>
+    <borderedNoOcclRMS>7.7319655418395996e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>2.9403196334838867e+01</borderedOcclRMS>
+    <borderedTexturedRMS>7.3328218460083008e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>8.1260728836059570e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>8.0057582855224609e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.2288767993450165e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.4875783026218414e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.8474562168121338e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.3391955196857452e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.6418045759201050e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.6844373345375061e-01</borderedDepthDiscontBadPxlsFraction></case_teddy_0>
+    <borderedAllBadPxlsFraction>2.2054961323738098e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.4624112844467163e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8428803682327271e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.3176816701889038e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.6128402948379517e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.6118943095207214e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>48</roiX>
+    <roiY>1</roiY>
+    <roiWidth>401</roiWidth>
+    <roiHeight>373</roiHeight></case_teddy_0>
   <case_teddy_1>
     <!-- RMS -->
-    <borderedAllRMS>1.1902968406677246e+01</borderedAllRMS>
-    <borderedNoOcclRMS>8.4395694732666016e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>2.9539928436279297e+01</borderedOcclRMS>
-    <borderedTexturedRMS>7.7252955436706543e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>9.1228895187377930e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>9.9976902008056641e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.1536233901977539e+01</borderedAllRMS>
+    <borderedNoOcclRMS>7.9090995788574219e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>2.9415622711181641e+01</borderedOcclRMS>
+    <borderedTexturedRMS>7.3498511314392090e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>8.4512376785278320e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>8.6553812026977539e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>2.2446873784065247e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.5042828023433685e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.8611855506896973e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>1.3583989441394806e-01</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>1.6559113562107086e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.8014644980430603e-01</borderedDepthDiscontBadPxlsFraction></case_teddy_1>
+    <borderedAllBadPxlsFraction>2.2115254402160645e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.4685927331447601e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8550838232040405e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>1.3280776143074036e-01</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.6146412491798401e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.7179715037345886e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>48</roiX>
+    <roiY>1</roiY>
+    <roiWidth>401</roiWidth>
+    <roiHeight>373</roiHeight></case_teddy_1>
   <case_tsukuba_0>
     <!-- RMS -->
-    <borderedAllRMS>1.6259672641754150e+00</borderedAllRMS>
-    <borderedNoOcclRMS>1.3531955480575562e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>5.7701373100280762e+00</borderedOcclRMS>
-    <borderedTexturedRMS>1.4829611778259277e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>1.1861004829406738e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.0144157409667969e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.4560865163803101e+00</borderedAllRMS>
+    <borderedNoOcclRMS>1.1663149595260620e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>5.5481433868408203e+00</borderedOcclRMS>
+    <borderedTexturedRMS>1.1953958272933960e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>1.1318612098693848e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>2.5299770832061768e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>6.5704256296157837e-02</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>4.4410109519958496e-02</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>8.6887413263320923e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>4.1421670466661453e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>4.7855451703071594e-02</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>1.8384420871734619e-01</borderedDepthDiscontBadPxlsFraction></case_tsukuba_0>
+    <borderedAllBadPxlsFraction>6.3446454703807831e-02</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>4.2244620621204376e-02</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>8.6313462257385254e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>3.8711227476596832e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>4.6318229287862778e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>1.7481118440628052e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>15</roiX>
+    <roiY>0</roiY>
+    <roiWidth>369</roiWidth>
+    <roiHeight>288</roiHeight></case_tsukuba_0>
   <case_tsukuba_1>
     <!-- RMS -->
-    <borderedAllRMS>1.6259672641754150e+00</borderedAllRMS>
-    <borderedNoOcclRMS>1.3531955480575562e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>5.7701373100280762e+00</borderedOcclRMS>
-    <borderedTexturedRMS>1.4829611778259277e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>1.1861004829406738e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>3.0144157409667969e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>1.3840254545211792e+00</borderedAllRMS>
+    <borderedNoOcclRMS>1.0908879041671753e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>5.4110512733459473e+00</borderedOcclRMS>
+    <borderedTexturedRMS>1.1951763629913330e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>9.5664811134338379e-01</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>2.4056303501129150e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>6.5704256296157837e-02</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>4.4410109519958496e-02</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>8.6887413263320923e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>4.1421670466661453e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>4.7855451703071594e-02</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>1.8384420871734619e-01</borderedDepthDiscontBadPxlsFraction></case_tsukuba_1>
+    <borderedAllBadPxlsFraction>5.5293288081884384e-02</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>3.4355212002992630e-02</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>8.4503310918807983e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>3.6525387316942215e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>3.1853232532739639e-02</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>1.5333925187587738e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>15</roiX>
+    <roiY>0</roiY>
+    <roiWidth>369</roiWidth>
+    <roiHeight>288</roiHeight></case_tsukuba_1>
   <case_venus_0>
     <!-- RMS -->
-    <borderedAllRMS>3.7822868824005127e+00</borderedAllRMS>
-    <borderedNoOcclRMS>3.4940557479858398e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>1.1360996246337891e+01</borderedOcclRMS>
-    <borderedTexturedRMS>3.1775889396667480e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.7477695941925049e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>2.8119759559631348e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>3.6029284000396729e+00</borderedAllRMS>
+    <borderedNoOcclRMS>3.2957947254180908e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>1.1354626655578613e+01</borderedOcclRMS>
+    <borderedTexturedRMS>3.1117112636566162e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.4480004310607910e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>2.7658543586730957e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.6210857033729553e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.4711523056030273e-01</borderedNoOcclBadPxlsFraction>
+    <borderedAllBadPxlsFraction>1.6096405684947968e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.4594979584217072e-01</borderedNoOcclBadPxlsFraction>
     <borderedOcclBadPxlsFraction>9.8257327079772949e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>7.1193501353263855e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>2.1318414807319641e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.1106897294521332e-01</borderedDepthDiscontBadPxlsFraction></case_venus_0>
+    <borderedTexturedBadPxlsFraction>7.1222625672817230e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>2.1097917854785919e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.0988385379314423e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>32</roiX>
+    <roiY>1</roiY>
+    <roiWidth>401</roiWidth>
+    <roiHeight>381</roiHeight></case_venus_0>
   <case_venus_1>
     <!-- RMS -->
-    <borderedAllRMS>3.7822868824005127e+00</borderedAllRMS>
-    <borderedNoOcclRMS>3.4940557479858398e+00</borderedNoOcclRMS>
-    <borderedOcclRMS>1.1360996246337891e+01</borderedOcclRMS>
-    <borderedTexturedRMS>3.1775889396667480e+00</borderedTexturedRMS>
-    <borderedTexturelessRMS>3.7477695941925049e+00</borderedTexturelessRMS>
-    <borderedDepthDiscontRMS>2.8119759559631348e+00</borderedDepthDiscontRMS>
+    <borderedAllRMS>3.4233355522155762e+00</borderedAllRMS>
+    <borderedNoOcclRMS>3.0939040184020996e+00</borderedNoOcclRMS>
+    <borderedOcclRMS>1.1366893768310547e+01</borderedOcclRMS>
+    <borderedTexturedRMS>3.0266089439392090e+00</borderedTexturedRMS>
+    <borderedTexturelessRMS>3.1512966156005859e+00</borderedTexturelessRMS>
+    <borderedDepthDiscontRMS>3.0161437988281250e+00</borderedDepthDiscontRMS>
     <!-- BadPxlsFraction -->
-    <borderedAllBadPxlsFraction>1.6210857033729553e-01</borderedAllBadPxlsFraction>
-    <borderedNoOcclBadPxlsFraction>1.4711523056030273e-01</borderedNoOcclBadPxlsFraction>
-    <borderedOcclBadPxlsFraction>9.8257327079772949e-01</borderedOcclBadPxlsFraction>
-    <borderedTexturedBadPxlsFraction>7.1193501353263855e-02</borderedTexturedBadPxlsFraction>
-    <borderedTexturelessBadPxlsFraction>2.1318414807319641e-01</borderedTexturelessBadPxlsFraction>
-    <borderedDepthDiscontBadPxlsFraction>2.1106897294521332e-01</borderedDepthDiscontBadPxlsFraction></case_venus_1></stereo_matching>
+    <borderedAllBadPxlsFraction>1.4581254124641418e-01</borderedAllBadPxlsFraction>
+    <borderedNoOcclBadPxlsFraction>1.3050784170627594e-01</borderedNoOcclBadPxlsFraction>
+    <borderedOcclBadPxlsFraction>9.8331481218338013e-01</borderedOcclBadPxlsFraction>
+    <borderedTexturedBadPxlsFraction>6.9387815892696381e-02</borderedTexturedBadPxlsFraction>
+    <borderedTexturelessBadPxlsFraction>1.8369597196578979e-01</borderedTexturelessBadPxlsFraction>
+    <borderedDepthDiscontBadPxlsFraction>2.3607489466667175e-01</borderedDepthDiscontBadPxlsFraction>
+    <!-- ValidDisparityROI -->
+    <roiX>32</roiX>
+    <roiY>1</roiY>
+    <roiWidth>401</roiWidth>
+    <roiHeight>381</roiHeight></case_venus_1></stereo_matching>
 </opencv_storage>


### PR DESCRIPTION
**Merge with opencv:** opencv/opencv#9974

This commit updates testdata to validate the disparity region of interest (disparity ROI) fix to StereoBM committed in opencv/opencv#9974, and makes corresponding ROI checking for StereoSGBM, as well as testing the 'fullDP=1' mode of StereoSGBM (instead of testing fullDP=0 twice). The results data change is a subset of the corresponding testdata committed to and validated against master.