### PR TITLE
Remove tf.pad from OpenCV's face detection network

### DIFF
--- a/testdata/dnn/opencv_face_detector.pbtxt
+++ b/testdata/dnn/opencv_face_detector.pbtxt
@@ -36,10 +36,54 @@ node {
   input: "data_scale/add"
 }
 node {
+  name: "SpaceToBatchND/block_shape"
+  op: "Const"
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        int_val: 1
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "SpaceToBatchND/paddings"
+  op: "Const"
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+          dim {
+            size: 2
+          }
+        }
+        int_val: 3
+        int_val: 3
+        int_val: 3
+        int_val: 3
+      }
+    }
+  }
+}
+node {
   name: "Pad"
-  op: "Pad"
+  op: "SpaceToBatchND"
   input: "data_scale/BiasAdd"
-  input: "Pad/paddings"
+  input: "SpaceToBatchND/block_shape"
+  input: "SpaceToBatchND/paddings"
 }
 node {
   name: "conv1_h/Conv2D"
@@ -439,10 +483,35 @@ node {
   input: "layer_256_1_scale1/BiasAdd"
 }
 node {
+  name: "SpaceToBatchND_1/paddings"
+  op: "Const"
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+          dim {
+            size: 2
+          }
+        }
+        int_val: 1
+        int_val: 1
+        int_val: 1
+        int_val: 1
+      }
+    }
+  }
+}
+node {
   name: "Pad_1"
-  op: "Pad"
+  op: "SpaceToBatchND"
   input: "Relu_4"
-  input: "Pad_1/paddings"
+  input: "SpaceToBatchND/block_shape"
+  input: "SpaceToBatchND_1/paddings"
 }
 node {
   name: "layer_256_1_conv_expand/Conv2D"
@@ -806,12 +875,6 @@ node {
   input: "Relu_7"
   input: "layer_512_1_conv2_h/convolution/SpaceToBatchND/block_shape"
   input: "layer_512_1_conv2_h/convolution/SpaceToBatchND/paddings"
-  attr {
-    key: "Tblock_shape"
-    value {
-      type: DT_INT32
-    }
-  }
 }
 node {
   name: "layer_512_1_conv2_h/convolution"
@@ -853,18 +916,6 @@ node {
   input: "layer_512_1_conv2_h/convolution"
   input: "layer_512_1_conv2_h/convolution/BatchToSpaceND/block_shape"
   input: "layer_512_1_conv2_h/convolution/BatchToSpaceND/crops"
-  attr {
-    key: "Tblock_shape"
-    value {
-      type: DT_INT32
-    }
-  }
-  attr {
-    key: "Tcrops"
-    value {
-      type: DT_INT32
-    }
-  }
 }
 node {
   name: "add_3"
@@ -1041,9 +1092,10 @@ node {
 }
 node {
   name: "Pad_2"
-  op: "Pad"
+  op: "SpaceToBatchND"
   input: "conv7_1_h/Relu"
-  input: "Pad_2/paddings"
+  input: "SpaceToBatchND/block_shape"
+  input: "SpaceToBatchND_1/paddings"
 }
 node {
   name: "conv7_2_h/Conv2D"

--- a/testdata/dnn/opencv_face_detector.pbtxt
+++ b/testdata/dnn/opencv_face_detector.pbtxt
@@ -126,9 +126,14 @@ node {
   input: "conv1_h/bias"
 }
 node {
+  name: "BatchToSpaceND"
+  op: "BatchToSpaceND"
+  input: "conv1_h/BiasAdd"
+}
+node {
   name: "conv1_bn_h/FusedBatchNorm"
   op: "FusedBatchNorm"
-  input: "conv1_h/BiasAdd"
+  input: "BatchToSpaceND"
   input: "conv1_bn_h/gamma"
   input: "conv1_bn_h/beta"
   input: "conv1_bn_h/mean"
@@ -507,13 +512,6 @@ node {
   }
 }
 node {
-  name: "Pad_1"
-  op: "SpaceToBatchND"
-  input: "Relu_4"
-  input: "SpaceToBatchND/block_shape"
-  input: "SpaceToBatchND_1/paddings"
-}
-node {
   name: "layer_256_1_conv_expand/Conv2D"
   op: "Conv2D"
   input: "Relu_4"
@@ -650,6 +648,13 @@ node {
   input: "conv4_3_norm_mbox_conf/BiasAdd"
 }
 node {
+  name: "Pad_1"
+  op: "SpaceToBatchND"
+  input: "Relu_4"
+  input: "SpaceToBatchND/block_shape"
+  input: "SpaceToBatchND_1/paddings"
+}
+node {
   name: "layer_256_1_conv1/Conv2D"
   op: "Conv2D"
   input: "Pad_1"
@@ -690,9 +695,14 @@ node {
   input: "layer_256_1_conv1/Conv2D_bn_offset"
 }
 node {
+  name: "BatchToSpaceND_1"
+  op: "BatchToSpaceND"
+  input: "layer_256_1_bn2/FusedBatchNorm"
+}
+node {
   name: "layer_256_1_scale2/Mul"
   op: "Mul"
-  input: "layer_256_1_bn2/FusedBatchNorm"
+  input: "BatchToSpaceND_1"
   input: "layer_256_1_scale2/mul"
 }
 node {
@@ -1138,9 +1148,14 @@ node {
   input: "conv7_2_h/bias"
 }
 node {
+  name: "BatchToSpaceND_2"
+  op: "BatchToSpaceND"
+  input: "conv7_2_h/BiasAdd"
+}
+node {
   name: "conv7_2_h/Relu"
   op: "Relu"
-  input: "conv7_2_h/BiasAdd"
+  input: "BatchToSpaceND_2"
 }
 node {
   name: "conv8_1_h/Conv2D"


### PR DESCRIPTION
Note: to keep an origin `.pb` model, const blobs such `SpaceToBatchND/block_shape` and `SpaceToBatchND/paddings` are redefined in text file.

```
allow_multiple_commits=1
```