### PR TITLE
Fix global variable reference

### DIFF
--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -37,7 +37,7 @@ class Model:
     def verify(self):
         if not self.sha:
             return False
-        print('  expect {}'.format(m.sha))
+        print('  expect {}'.format(self.sha))
         sha = hashlib.sha1()
         with open(self.filename, 'rb') as f:
             while True:


### PR DESCRIPTION
This change allows this file to be called as a module and not have to download all the models.

ie:

```
from opencv_extra.testdata.dnn.download_models import models
for m in [m for m in models if m.name == 'EAST']:
    print(m)
    m.get()
```

Without this change it throws an error to say that `m` is not defined.