### PR TITLE
download_models.py continues, if a particular resource is not available.

### DIFF
--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -781,12 +781,21 @@ models = [
 #       expected working directory is opencv_extra/testdata/dnn
 if __name__ == '__main__':
     failedSums = []
+    failedGets = []
     for m in models:
         print(m)
-        if not m.get():
-            failedSums.append(m.filename)
+        try:
+            if not m.get():
+                failedSums.append(m.filename)
+        except Exception as e:
+            print(' catch {}'.format(e))
+            failedGets.append(m.filename)
     if failedSums:
         print("Checksum verification failed for:")
         for f in failedSums:
+            print("* {}".format(f))
+    if failedGets:
+        print("Getting the model failed for:")
+        for f in failedGets:
             print("* {}".format(f))
         exit(15)


### PR DESCRIPTION
Current implementation of dnn/download_models.py fails on exception if a model download fails and does not continue donwloading the rest of models.  
This behavior is inconvenient as link on some models might get invalid in future - happened recently with Enet model. Also in corporate environment, access to some cloud storage services might be blocked. 
This behavior is fixed - in proposed change, the script continues with other models after download failure. 