### PR TITLE
estimateChessboardSharpness: add sharpness value to chessboard meta data

### DIFF
--- a/testdata/cv/cameracalibration/chess_corners1.dat
+++ b/testdata/cv/cameracalibration/chess_corners1.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 1.9
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners2.dat
+++ b/testdata/cv/cameracalibration/chess_corners2.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 2.0
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners3.dat
+++ b/testdata/cv/cameracalibration/chess_corners3.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 2.1
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners4.dat
+++ b/testdata/cv/cameracalibration/chess_corners4.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 2.05
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners5.dat
+++ b/testdata/cv/cameracalibration/chess_corners5.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 2.35
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners6.dat
+++ b/testdata/cv/cameracalibration/chess_corners6.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 2.45
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners7.dat
+++ b/testdata/cv/cameracalibration/chess_corners7.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 1.91
 corners: !!opencv-matrix
    rows: 7
    cols: 5

--- a/testdata/cv/cameracalibration/chess_corners8.dat
+++ b/testdata/cv/cameracalibration/chess_corners8.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 1.45
 corners: !!opencv-matrix
    rows: 6
    cols: 4

--- a/testdata/cv/cameracalibration/chess_corners9.dat
+++ b/testdata/cv/cameracalibration/chess_corners9.dat
@@ -1,5 +1,6 @@
 %YAML:1.0
 isFound: 1
+sharpness: 2.23
 corners: !!opencv-matrix
    rows: 21
    cols: 19


### PR DESCRIPTION
For testing estimateChessboardSharpness (https://github.com/opencv/opencv/pull/16625) the meta data of chessboard images is extended.

The sharpness of a chessboard is calculated by traveling from detected
black to white cells and cacluating the number of pixels required for a
transistion from black to white (step response).


