### PR TITLE
fix: Bad whitespace - there was a space before 'class' on several lines.

### DIFF
--- a/testdata/dnn/onnx/generate_onnx_models.py
+++ b/testdata/dnn/onnx/generate_onnx_models.py
@@ -813,7 +813,7 @@ model = UpsampleUnfusedTwoInput()
 save_data_and_model_multy_inputs("upsample_unfused_two_inputs_opset9_torch1.4", UpsampleUnfusedTwoInput(), input_0, input_1, version=9)
 save_data_and_model_multy_inputs("upsample_unfused_two_inputs_opset11_torch1.4", UpsampleUnfusedTwoInput(), input_0, input_1, version=11)
 
- class FrozenBatchNorm2d(nn.Module):
+class FrozenBatchNorm2d(nn.Module):
     def __init__(self, n):
         super(FrozenBatchNorm2d, self).__init__()
         self.register_buffer("weight", torch.ones(n))
@@ -832,7 +832,7 @@ x = Variable(torch.randn(1, 2, 3, 4))
 model = FrozenBatchNorm2d(2)
 save_data_and_model("batch_norm_subgraph", x, model)
 
- class GatherScalar(nn.Module):
+class GatherScalar(nn.Module):
     def forward(self, x):
         return x[1]
 
@@ -840,7 +840,7 @@ x = Variable(torch.randn(2))
 model = GatherScalar()
 save_data_and_model("gather_scalar", x, model)
 
- class Gather(nn.Module):
+class Gather(nn.Module):
     def forward(self, x):
         return x[..., 1]
 


### PR DESCRIPTION
Since python is a whitespace sensitive language, misplaced whitespace
can make it unparseable.  This commit fixes several places where there
was bad whitespace.