### PR TITLE
Update download_models.py

### DIFF
--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -61,7 +61,7 @@ class Model:
             return True
 
         basedir = os.path.dirname(self.filename)
-        if not os.path.exists(basedir):
+        if basedir and not os.path.exists(basedir):
             print('  creating directory: ' + basedir)
             os.makedirs(basedir, exist_ok=True)
 


### PR DESCRIPTION
The fix for issue (https://github.com/opencv/opencv_contrib/issues/941) introduced a defect.

Steps to reproduce the defect:
1. download model GoogleNet using command on windows: python download_models.py GoogleNet
2. there is an exception and downloading is failed.

Root cause analysis
1. filename is "bvlc_googlenet.caffemodel"
2.  the basedir for model storage is empty with following statement
     basedir = os.path.dirname(self.filename)
3.  os.path.mkdir('') throws exception
Traceback (most recent call last):
  File "download_models.py", line 883, in <module>
    if not m.get():
  File "download_models.py", line 66, in get
    os.makedirs(basedir, exist_ok=True)
  File "C:\Users\xiebian\miniconda3\envs\gluon\lib\os.py", line 220, in makedirs
    mkdir(name, mode)
FileNotFoundError: [WinError 3] 系统找不到指定的路径。: ''