### PR TITLE
another fix opencv/opencv#20575 -- dnn model downloader cleans invalid files

### DIFF
--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -82,7 +82,12 @@ class Model:
 
         print(' done')
         print(' file {}'.format(self.filename))
-        return self.verify()
+        candidate_verify = self.verify()
+        if not candidate_verify:
+            if os.path.exists(self.filename):
+                print('  deleting invalid file')
+                os.remove(self.filename)
+        return candidate_verify
 
     def download(self):
         try:


### PR DESCRIPTION
another fix for opencv/opencv#20575. The downloader will now delete invalid (bad hash) files. This prevents later failures in running OpenCV code which attempts to use invalid files.

tested on 3.4.  Approach should also work in 4.x