### PR TITLE
Weights for YoloX Yolo v6 and Yolo v8

### DIFF
--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -937,6 +937,11 @@ models = [
         sha='fcd0fa401c83bf2b29e18239a9c2c989c9b8669d',
         filename='onnx/models/yolov7_not_simplified.onnx'),
     Model(
+        name='yolox_s_inf_decoder',
+        url='https://drive.google.com/u/0/uc?id=12dVy3ob7T4fYHOkLYnrpUmlysq6JEc5P&export=download',
+        sha='b205b00122cc7bf559a0e845680408320df3a898',
+        filename='onnx/models/yolox_s_inf_decoder.onnx'),
+    Model(
         name='NanoTrackV1 (ONNX, backbone)',
         url='https://raw.githubusercontent.com/zihaomu/opencv_extra_data_backup/main/NanoTrack/models/nanotrack_backbone_sim.onnx',
         sha='9b083a2dbe10dcfe17e694879aa6749302a5888f',

--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -933,14 +933,24 @@ models = [
         filename='wechat_2021-01/sr.caffemodel'),
     Model(
         name='yolov7_not_simplified',
-        gdrive='1rm3mIqjJNu0xPTCjMKnXccspazV1B2zv',
+        url='https://dl.opencv.org/models/yolov7/yolov7_not_simplified.onnx',
         sha='fcd0fa401c83bf2b29e18239a9c2c989c9b8669d',
         filename='onnx/models/yolov7_not_simplified.onnx'),
     Model(
         name='yolox_s_inf_decoder',
-        url='https://drive.google.com/u/0/uc?id=12dVy3ob7T4fYHOkLYnrpUmlysq6JEc5P&export=download',
+        url='https://dl.opencv.org/models/yolox/yolox_s_inf_decoder.onnx',
         sha='b205b00122cc7bf559a0e845680408320df3a898',
         filename='onnx/models/yolox_s_inf_decoder.onnx'),
+    Model(
+        name='yolov6n',
+        url='https://dl.opencv.org/models/yolov6/yolov6n.onnx',
+        sha='a704c0ace51103a43920c50a396b2c8b09d2daec',
+        filename='onnx/models/yolov6n.onnx'),
+    Model(
+        name='yolov8n',
+        url='https://dl.opencv.org/models/yolov8/yolov8n.onnx',
+        sha='136807b88d0b02bc226bdeb9741141d857752e10',
+        filename='onnx/models/yolov8n.onnx'),
     Model(
         name='NanoTrackV1 (ONNX, backbone)',
         url='https://raw.githubusercontent.com/zihaomu/opencv_extra_data_backup/main/NanoTrack/models/nanotrack_backbone_sim.onnx',


### PR DESCRIPTION
This PR extends download functionality for weights of yolox model from google drive

### Problem
Yolox model weights are required for test in opencv repository (PR with the test is yet to be opened) 