### PR TITLE
Changed onnx weights of yolov7

### DIFF
--- a/testdata/dnn/download_models.py
+++ b/testdata/dnn/download_models.py
@@ -988,13 +988,12 @@ models = [
         sha='2b181b55d1d7af718eaca6cabdeb741217b64c73',
         filename='wechat_2021-01/sr.caffemodel'),
     Model(
-        name='yolov7_not_simplified',
+        name='yolov7',
         url=[
-            'https://docs.google.com/uc?export=download&id=1ljSh81ydO5ylsnDoV_mt3zj5RX_cgLu8',
-            'https://dl.opencv.org/models/yolov7/yolov7_not_simplified.onnx'
+            'https://dl.opencv.org/models/yolov7/yolov7.onnx'
         ],
-        sha='fcd0fa401c83bf2b29e18239a9c2c989c9b8669d',
-        filename='onnx/models/yolov7_not_simplified.onnx'),
+        sha='9f5199c266418462771a26a7b8ea25a90412ce2e',
+        filename='onnx/models/yolov7.onnx'),
     Model(
         name='yolox_s_inf_decoder',
         url=[


### PR DESCRIPTION
This pull request changes downloading of weight download of yolov7 model. This was required as the onnx graph of the previous yolov7 outputted detections and **as well as features maps of the model**. Having vector of 4 tensors would make [unification of API for YOLO models](https://github.com/opencv/opencv/pull/24691#discussion_r1435033606) problematic, thus change was required.

Test for these weight are located in this [#24783](https://github.com/opencv/opencv/pull/24783)