### PR TITLE
video: update ECC perf sanity baselines for the pre-filter border fix 🤖🤖🤖

### DIFF
--- a/testdata/perf/video.xml
+++ b/testdata/perf/video.xml
@@ -12858,6 +12858,8 @@
       <y>0</y>
       <val>0.</val></rng2></err></Path_Idx_Cn_NPoints_WSize_Deriv_OpticalFlowPyrLK_self--OpticalFlowPyrLK_self----cv-optflow-frames-VGA_-02d-png---1--1---15--15---11--true->
  <!-- resumed -->
+ <!-- resumed -->
+
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_TRANSLATION--IMREAD_GRAYSCALE->
   <warpMat>
     <kind>65536</kind>
@@ -12867,7 +12869,7 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        1. 0. 5.66389704 0. 1. 7.19798422</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_TRANSLATION--IMREAD_GRAYSCALE->
+        1. 0. 5.65288925 0. 1. 6.80625343</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_TRANSLATION--IMREAD_GRAYSCALE->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_TRANSLATION--IMREAD_COLOR->
   <warpMat>
     <kind>65536</kind>
@@ -12877,7 +12879,7 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        1. 0. 5.66389656 0. 1. 7.19798374</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_TRANSLATION--IMREAD_COLOR->
+        1. 0. 5.65288925 0. 1. 6.80625296</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_TRANSLATION--IMREAD_COLOR->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_EUCLIDEAN--IMREAD_GRAYSCALE->
   <warpMat>
     <kind>65536</kind>
@@ -12887,8 +12889,8 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        0.999972582 0.00740487082 -1.47809148 -0.00740487082 0.999972582
-        5.3313446</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_EUCLIDEAN--IMREAD_GRAYSCALE->
+        0.999907911 0.0135696558 -1.94013417 -0.0135696558 0.999907911
+        5.27542734</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_EUCLIDEAN--IMREAD_GRAYSCALE->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_EUCLIDEAN--IMREAD_COLOR->
   <warpMat>
     <kind>65536</kind>
@@ -12898,8 +12900,8 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        0.999972582 0.00740487454 -1.47809148 -0.00740487454 0.999972582
-        5.33134413</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_EUCLIDEAN--IMREAD_COLOR->
+        0.999907911 0.013569545 -1.94011176 -0.013569545 0.999907911
+        5.27540588</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_EUCLIDEAN--IMREAD_COLOR->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_AFFINE--IMREAD_GRAYSCALE->
   <warpMat>
     <kind>65536</kind>
@@ -12909,8 +12911,8 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        1.0263046 0.0180508792 6.01317453 0.00676508341 0.977224648
-        2.78590178</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_AFFINE--IMREAD_GRAYSCALE->
+        1.03070784 0.00589328166 6.50791359 0.00960378163 0.976322889
+        2.51011777</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_AFFINE--IMREAD_GRAYSCALE->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_AFFINE--IMREAD_COLOR->
   <warpMat>
     <kind>65536</kind>
@@ -12920,8 +12922,8 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        1.02630627 0.0180513505 6.01289415 0.00676529482 0.977226436
-        2.78549767</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_AFFINE--IMREAD_COLOR->
+        1.03070807 0.00589547772 6.50775671 0.00960300397 0.97632122
+        2.51032114</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_AFFINE--IMREAD_COLOR->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_HOMOGRAPHY--IMREAD_GRAYSCALE->
   <warpMat>
     <kind>65536</kind>
@@ -12931,8 +12933,8 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        1.14262474 -0.00949726813 3.55660748 0.0169195123 0.979393125
-        5.60513973 0.000735168403 1.47581377e-05 1.</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_HOMOGRAPHY--IMREAD_GRAYSCALE->
+        1.16192842 -0.00339250965 2.14204216 0.0217898674 0.988392591
+        5.29586744 0.000778613263 6.87419088e-05 1.</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_HOMOGRAPHY--IMREAD_GRAYSCALE->
 <ECCPerfTest_findTransformECC--findTransformECC---MOTION_HOMOGRAPHY--IMREAD_COLOR->
   <warpMat>
     <kind>65536</kind>
@@ -12942,6 +12944,6 @@
       <cols>3</cols>
       <dt>f</dt>
       <data>
-        1.13884926 -0.00999647379 3.63919997 0.0151256379 0.977176189
-        5.65469217 0.000721809047 5.96383688e-06 1.</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_HOMOGRAPHY--IMREAD_COLOR->
+        1.15949488 -0.00367058301 2.18706846 0.0206779055 0.986853778
+        5.30143356 0.000769746781 6.24072854e-05 1.</data></val></warpMat></ECCPerfTest_findTransformECC--findTransformECC---MOTION_HOMOGRAPHY--IMREAD_COLOR->
 </opencv_storage>


### PR DESCRIPTION
Companion to opencv/opencv#29775 (video: exclude the Gaussian pre-filter's extrapolated border ring from the ECC template mask).

`ECCPerfTest_findTransformECC` sanity-checks `warpMat` after exactly five iterations from identity (`TermCriteria(COUNT + EPS, 5, -1)`), i.e. a partially converged state — for the affine case the ground truth translation is 15.5 px while the stored baseline holds 6.0 px. A change to the update path therefore moves that intermediate state by far more than it moves the converged result, and the companion fix puts all eight cases past the 3e-3 tolerance (8.3e-3 for homography).

This updates only those eight `ECCPerfTest_findTransformECC` entries in `testdata/perf/video.xml` to the values the patched code produces. No other test data changes.

| case | before → after (translation entry) |
|---|---|
| MOTION_TRANSLATION | 7.198 → 6.806 |
| MOTION_EUCLIDEAN | 5.331 → 5.275 |
| MOTION_AFFINE | 2.786 → 2.510 |
| MOTION_HOMOGRAPHY | 5.655 → 5.301 |

To be clear about the direction of the change: the new values are not a worse result, they are a different point along the path. Run the same four scenarios to convergence instead of stopping at five iterations and the fix is better on every one of them (corner RMS against the ground-truth warp, over the 200x200 window, on `fruits_ecc.png`):

| motion | upstream | with the fix | rho |
|---|---:|---:|---|
| TRANSLATION | 0.021 px | **0.006 px** | 0.99989 -> 1.00000 |
| EUCLIDEAN | 0.018 px | **0.005 px** | 0.99932 -> 0.99944 |
| AFFINE | 0.034 px | **0.006 px** | 0.99976 -> 0.99996 |
| HOMOGRAPHY | 0.025 px | **0.009 px** | 0.99986 -> 0.99989 |

At the five iterations the perf test uses, neither version is anywhere near the ground truth (the affine ground-truth translation is 15.5 px; upstream reaches 6.0 px and the fix reaches 6.5 px, at rho 0.81), so the baseline pins a trajectory rather than a result.

Verified on 4.15.0-dev (MSVC 19.44.35222, Release x64): with the companion fix applied, `opencv_perf_video --gtest_filter=*ECCPerfTest_findTransformECC*` fails 8/8 against the old baseline and passes 8/8 against these values. With upstream `ecc.cpp` restored, the old baseline passes 8/8 — so the change is attributable to the fix rather than to this machine.

*Disclosure: prepared with AI assistance (Claude); the baselines were regenerated and verified on my own build.*
