### PR TITLE
Extended baseline for core

### DIFF
--- a/testdata/perf/core.xml
+++ b/testdata/perf/core.xml
@@ -79144,4 +79144,7154 @@
       <x>104</x>
       <y>45</y>
       <val>235.</val></rng2></dst></Size_Channel_extractChannel--extractChannel---127x61--1->
+ <!-- resumed -->
+
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>137</x>
+      <y>139</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>88</x>
+      <y>350</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>455</x>
+      <y>290</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>456</x>
+      <y>396</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>425</x>
+      <y>177</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>550</x>
+      <y>230</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>167</x>
+      <y>181</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>32</x>
+      <y>377</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>165</x>
+      <y>228</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>534</x>
+      <y>340</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>639</x>
+      <y>437</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>250</x>
+      <y>464</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16UC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>449</x>
+      <y>450</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>511</x>
+      <y>230</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>380</x>
+      <y>297</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>224</x>
+      <y>226</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>577</x>
+      <y>269</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>9</x>
+      <y>22</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>608</x>
+      <y>471</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>71</x>
+      <y>334</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>623</x>
+      <y>238</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>538</x>
+      <y>129</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>160</x>
+      <y>151</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>351</x>
+      <y>326</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---640x480--16SC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>627</x>
+      <y>171</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>63</x>
+      <y>252</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>33</x>
+      <y>278</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>236</x>
+      <y>630</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>701</x>
+      <y>561</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>1130</x>
+      <y>525</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>139</x>
+      <y>324</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>904</x>
+      <y>54</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>944</x>
+      <y>631</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>856</x>
+      <y>153</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>387</x>
+      <y>692</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>146</x>
+      <y>187</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16UC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>798</x>
+      <y>398</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>877</x>
+      <y>683</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>440</x>
+      <y>371</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>610</x>
+      <y>353</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>1246</x>
+      <y>539</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>757</x>
+      <y>551</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>916</x>
+      <y>137</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>1113</x>
+      <y>570</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>1226</x>
+      <y>570</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>1170</x>
+      <y>191</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>407</x>
+      <y>322</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>105</x>
+      <y>109</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1280x720--16SC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>162</x>
+      <y>101</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>1616</x>
+      <y>716</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>348</x>
+      <y>203</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>292</x>
+      <y>50</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>165</x>
+      <y>478</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>400</x>
+      <y>683</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>1540</x>
+      <y>725</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>1866</x>
+      <y>592</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>1132</x>
+      <y>191</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>351</x>
+      <y>149</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>1391</x>
+      <y>663</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>294</x>
+      <y>367</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16UC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>1574</x>
+      <y>716</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>1010</x>
+      <y>291</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>1640</x>
+      <y>521</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>1809</x>
+      <y>5</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>1562</x>
+      <y>236</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>579</x>
+      <y>136</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>1833</x>
+      <y>405</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>425</x>
+      <y>554</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>87</x>
+      <y>892</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>1469</x>
+      <y>250</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>850</x>
+      <y>1019</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>1880</x>
+      <y>418</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---1920x1080--16SC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>25</x>
+      <y>34</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>72</x>
+      <y>26</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>9</x>
+      <y>49</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>56</x>
+      <y>42</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>10</x>
+      <y>29</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>66</x>
+      <y>28</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>62</x>
+      <y>28</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>14</x>
+      <y>58</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>19</x>
+      <y>31</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>118</x>
+      <y>19</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>11</x>
+      <y>21</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>27</x>
+      <y>21</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16UC1--CMP_NE->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_EQ->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>0.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>58</x>
+      <y>12</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>122</x>
+      <y>6</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_EQ->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_GT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>2</x>
+      <y>42</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>79</x>
+      <y>46</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_GT->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_GE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>0.</val></last>
+    <rng1>
+      <x>8</x>
+      <y>13</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>68</x>
+      <y>52</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_GE->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_LT->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>119</x>
+      <y>56</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>115</x>
+      <y>42</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_LT->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_LE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>0.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>65</x>
+      <y>12</y>
+      <val>0.</val></rng1>
+    <rng2>
+      <x>65</x>
+      <y>42</y>
+      <val>0.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_LE->
+<Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_NE->
+  <dst>
+    <kind>65536</kind>
+    <type>0</type>
+    <min>255.</min>
+    <max>255.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>255.</val></last>
+    <rng1>
+      <x>118</x>
+      <y>11</y>
+      <val>255.</val></rng1>
+    <rng2>
+      <x>4</x>
+      <y>2</y>
+      <val>255.</val></rng2></dst></Size_MatType_CmpType_compareScalar--compareScalar---127x61--16SC1--CMP_NE->
+<MatType_Length_dot--dot---64FC1--32->
+  <product>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        81364526.366193503</data></val></product></MatType_Length_dot--dot---64FC1--32->
+<MatType_Length_dot--dot---64FC1--64->
+  <product>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -231731388.02419645</data></val></product></MatType_Length_dot--dot---64FC1--64->
+<MatType_Length_dot--dot---64FC1--128->
+  <product>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        491932440.31229204</data></val></product></MatType_Length_dot--dot---64FC1--128->
+<MatType_Length_dot--dot---64FC1--256->
+  <product>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -737299334.45668328</data></val></product></MatType_Length_dot--dot---64FC1--256->
+<MatType_Length_dot--dot---64FC1--512->
+  <product>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -1081914230.1840947</data></val></product></MatType_Length_dot--dot---64FC1--512->
+<MatType_Length_dot--dot---64FC1--1024->
+  <product>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2751369292.9888258</data></val></product></MatType_Length_dot--dot---64FC1--1024->
+<Size_MatType_Mat_CopyToWithMask--Mat_CopyToWithMask---1920x1080--32FC3->
+  <dst>
+    <kind>65536</kind>
+    <type>21</type>
+    <min>-4094.99853515625</min>
+    <max>4094.998779296875</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>2273.29443359375</val></last>
+    <rng1>
+      <x>1718</x>
+      <y>990</y>
+      <cn>2</cn>
+      <val>3319.42431640625</val></rng1>
+    <rng2>
+      <x>1295</x>
+      <y>318</y>
+      <cn>1</cn>
+      <val>-4029.85888671875</val></rng2></dst></Size_MatType_Mat_CopyToWithMask--Mat_CopyToWithMask---1920x1080--32FC3->
+<Size_MatType_Mat_CopyToWithMask--Mat_CopyToWithMask---127x61--32FC3->
+  <dst>
+    <kind>65536</kind>
+    <type>21</type>
+    <min>-4094.445556640625</min>
+    <max>4094.807861328125</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>-2862.47802734375</val></last>
+    <rng1>
+      <x>83</x>
+      <y>37</y>
+      <cn>1</cn>
+      <val>2040.5640869140625</val></rng1>
+    <rng2>
+      <x>74</x>
+      <y>49</y>
+      <val>705.9945068359375</val></rng2></dst></Size_MatType_Mat_CopyToWithMask--Mat_CopyToWithMask---127x61--32FC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--8UC3->
+  <src>
+    <kind>65536</kind>
+    <type>16</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>189</x>
+      <y>69</y>
+      <cn>2</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>212</x>
+      <y>39</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--8UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--8UC4->
+  <src>
+    <kind>65536</kind>
+    <type>24</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>485</x>
+      <y>195</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>212</x>
+      <y>235</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--8UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--16UC3->
+  <src>
+    <kind>65536</kind>
+    <type>18</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>95</x>
+      <y>34</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>619</x>
+      <y>461</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--16UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--16UC4->
+  <src>
+    <kind>65536</kind>
+    <type>26</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>326</x>
+      <y>469</y>
+      <cn>3</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>366</x>
+      <y>465</y>
+      <cn>2</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--16UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--32FC3->
+  <src>
+    <kind>65536</kind>
+    <type>21</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>591</x>
+      <y>162</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>515</x>
+      <y>84</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--32FC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--32FC4->
+  <src>
+    <kind>65536</kind>
+    <type>29</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>322</x>
+      <y>65</y>
+      <cn>2</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>359</x>
+      <y>106</y>
+      <cn>2</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---640x480--32FC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--8UC3->
+  <src>
+    <kind>65536</kind>
+    <type>16</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>984</x>
+      <y>178</y>
+      <cn>2</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>608</x>
+      <y>431</y>
+      <cn>2</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--8UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--8UC4->
+  <src>
+    <kind>65536</kind>
+    <type>24</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>249</x>
+      <y>184</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>34</x>
+      <y>682</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--8UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--16UC3->
+  <src>
+    <kind>65536</kind>
+    <type>18</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>150</x>
+      <y>657</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>575</x>
+      <y>96</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--16UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--16UC4->
+  <src>
+    <kind>65536</kind>
+    <type>26</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>390</x>
+      <y>316</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>825</x>
+      <y>591</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--16UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--32FC3->
+  <src>
+    <kind>65536</kind>
+    <type>21</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>201</x>
+      <y>276</y>
+      <cn>2</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>794</x>
+      <y>624</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--32FC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--32FC4->
+  <src>
+    <kind>65536</kind>
+    <type>29</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>110</x>
+      <y>685</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>508</x>
+      <y>164</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1280x720--32FC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--8UC3->
+  <src>
+    <kind>65536</kind>
+    <type>16</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>107</x>
+      <y>581</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>393</x>
+      <y>273</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--8UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--8UC4->
+  <src>
+    <kind>65536</kind>
+    <type>24</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>274</x>
+      <y>446</y>
+      <cn>3</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>982</x>
+      <y>435</y>
+      <cn>2</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--8UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--16UC3->
+  <src>
+    <kind>65536</kind>
+    <type>18</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>1293</x>
+      <y>702</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>141</x>
+      <y>596</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--16UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--16UC4->
+  <src>
+    <kind>65536</kind>
+    <type>26</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>552</x>
+      <y>68</y>
+      <cn>3</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>1250</x>
+      <y>708</y>
+      <cn>3</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--16UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--32FC3->
+  <src>
+    <kind>65536</kind>
+    <type>21</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>1511</x>
+      <y>885</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>120</x>
+      <y>540</y>
+      <cn>2</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--32FC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--32FC4->
+  <src>
+    <kind>65536</kind>
+    <type>29</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>1292</x>
+      <y>698</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>1787</x>
+      <y>1045</y>
+      <cn>3</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---1920x1080--32FC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--8UC3->
+  <src>
+    <kind>65536</kind>
+    <type>16</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>91</x>
+      <y>25</y>
+      <cn>2</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>119</x>
+      <y>27</y>
+      <cn>2</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--8UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--8UC4->
+  <src>
+    <kind>65536</kind>
+    <type>24</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>32</x>
+      <y>27</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>106</x>
+      <y>48</y>
+      <cn>3</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--8UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--16UC3->
+  <src>
+    <kind>65536</kind>
+    <type>18</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>13</x>
+      <y>53</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>31</x>
+      <y>33</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--16UC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--16UC4->
+  <src>
+    <kind>65536</kind>
+    <type>26</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>74</x>
+      <y>36</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>29</x>
+      <y>52</y>
+      <cn>1</cn>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--16UC4->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--32FC3->
+  <src>
+    <kind>65536</kind>
+    <type>21</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>7</x>
+      <y>49</y>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>61</x>
+      <y>7</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--32FC3->
+<Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--32FC4->
+  <src>
+    <kind>65536</kind>
+    <type>29</type>
+    <min>0.</min>
+    <max>27.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>27.</val></last>
+    <rng1>
+      <x>10</x>
+      <y>59</y>
+      <cn>1</cn>
+      <val>27.</val></rng1>
+    <rng2>
+      <x>114</x>
+      <y>59</y>
+      <val>27.</val></rng2></src></Size_MatType_Mat_SetToWithMask--Mat_SetToWithMask---127x61--32FC4->
+<Size_MatType_NormType_norm--norm---640x480--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6662329665.999999</data></val></n></Size_MatType_NormType_norm--norm---640x480--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        26666716429</data></val></n></Size_MatType_NormType_norm--norm---640x480--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1677365058.</data></val></n></Size_MatType_NormType_norm--norm---640x480--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        440064726816579.06</data></val></n></Size_MatType_NormType_norm--norm---640x480--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        109877408585539</data></val></n></Size_MatType_NormType_norm--norm---640x480--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4.7125245164293687e+23</data></val></n></Size_MatType_NormType_norm--norm---640x480--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1713569421634.0217</data></val></n></Size_MatType_NormType_norm--norm---640x480--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---640x480--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1713569421533.8154</data></val></n></Size_MatType_NormType_norm--norm---640x480--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        19993555884</data></val></n></Size_MatType_NormType_norm--norm---1280x720--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        79999699609</data></val></n></Size_MatType_NormType_norm--norm---1280x720--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5032675756</data></val></n></Size_MatType_NormType_norm--norm---1280x720--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1318238639807038</data></val></n></Size_MatType_NormType_norm--norm---1280x720--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        329571982301758.06</data></val></n></Size_MatType_NormType_norm--norm---1280x720--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.4155815523207679e+24</data></val></n></Size_MatType_NormType_norm--norm---1280x720--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5147341416090.7676</data></val></n></Size_MatType_NormType_norm--norm---1280x720--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1280x720--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5147341416035.4453</data></val></n></Size_MatType_NormType_norm--norm---1280x720--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        44978217242.000008</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        180066785836</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11320981274</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2965436271095472</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        742324849536688.12</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3.1853478402055675e+24</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11582570312112.25</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---1920x1080--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11582570312173.494</data></val></n></Size_MatType_NormType_norm--norm---1920x1080--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        166816112.</data></val></n></Size_MatType_NormType_norm--norm---127x61--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        671820627.</data></val></n></Size_MatType_NormType_norm--norm---127x61--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        42822512.</data></val></n></Size_MatType_NormType_norm--norm---127x61--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11002136993053</data></val></n></Size_MatType_NormType_norm--norm---127x61--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2786130631964.9995</data></val></n></Size_MatType_NormType_norm--norm---127x61--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.1762888335981688e+22</data></val></n></Size_MatType_NormType_norm--norm---127x61--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        42772245913.689812</data></val></n></Size_MatType_NormType_norm--norm---127x61--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm--norm---127x61--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        42772245939.858223</data></val></n></Size_MatType_NormType_norm--norm---127x61--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6662329665.999999</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        117409808.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        141398.57101116687</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        19993555884</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        26666716429</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1677365058.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        440064726816579.06</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65535.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30174609814</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        36307556.235679619</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1318238639807038</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        109877408585539</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4.7125245164293935e+23</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1713569420424.0002</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4094.991943359375</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1885841842.359375</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2268775.3130673827</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5147341421184</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---640x480--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1713569421533.854</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---640x480--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        19993555884</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        352290057.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        244917.57628026616</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        59984619170.999992</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        79999699609</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5032675756</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1318238639807038</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65535.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        90550417543</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        62889385.076705635</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3955074755326165.5</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        329571982301758</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.4155815523208194e+24</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5147341420895.999</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4094.998779296875</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5658912683.4375</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3929902.1845129938</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        15444131179840</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1280x720--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5147341416035.377</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1280x720--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        44978217242.000008</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        793077141.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        367512.91671586182</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        135065743952.99998</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        180066785836</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11320981274</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2965436271095472</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65535.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        203756405958</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        94342566.000654951</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8900519759587935</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        742324849536688</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3.1853478402056191e+24</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11582570312928</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4094.998779296875</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        12736073224.96875</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5896118.5257883007</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        34764213670144.004</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---1920x1080--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11582570312174.295</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---1920x1080--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        166816112.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2957262.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        22413.783973260743</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        502377712.00000012</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        671820627.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        42822512.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        11002136993053</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65535.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        760026328.</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5766561.5069930544</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        33253231613934.008</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2786130631965</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.1762888335981657e+22</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        42772245970.402351</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4094.807861328125</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_INF->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        47433091.974609375</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_L1->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        359855.05485542375</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        129495660505.00003</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm_mask--norm_mask---127x61--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        42772245939.858154</data></val></n></Size_MatType_NormType_norm_mask--norm_mask---127x61--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3352108710.0000005</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.5028770281971271</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        13417796887</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50325740608569647</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3349837478</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9959033912630115</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        220317810089563</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50163038961182183</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        219713274830427</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9991462596247043</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        9.4101812958619299e+23</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950699504381633</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3421732632347.4092</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950699503806502</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---640x480--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3421732632580.7739</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---640x480--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950699504391582</data></val></n></Size_MatType_NormType_norm2--norm2---640x480--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10070266787</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50378782761890095</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        40233638484</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50241603159627923</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10056377251</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9994022713305322</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        659651140750205</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50053374140812568</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        658894550698877</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950720844455843</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.8318736816543229e+24</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487813248682</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10297266634626.023</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487814206474</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1280x720--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10297266634099.629</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1280x720--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487813246095</data></val></n></Size_MatType_NormType_norm2--norm2---1280x720--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        22657955065.000004</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50355244156544543</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        90601148911</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50333498706877711</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        22659498745</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9989918413873182</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1482709467830083</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.49926350708770828</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1481659617679171</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9957369850784612</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6.3752211994030978e+24</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003021400456702</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        23181596327210.039</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003021401564531</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---1920x1080--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        23181596328585.473</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---1920x1080--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003021400448748</data></val></n></Size_MatType_NormType_norm2--norm2---1920x1080--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        82154407.000000015</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.49012002941516958</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        339535659.</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50799604434877432</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        85293479.</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9822857260123403</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5565548588686.999</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.4962127254724607</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5519312023218.001</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.019326771007266</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.3765786277490947e+22</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950645589785481</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        86417215463.59259</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950645583897222</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2--norm2---127x61--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        86417215447.745071</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2--norm2---127x61--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950645589556408</data></val></n></Size_MatType_NormType_norm2--norm2---127x61--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3352108710.0000005</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.5028770281971271</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        78631355.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        100350.71891620907</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10070266787</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.66982335751439459</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.70978012624960207</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50378782761890106</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        13417796887</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50325740608569636</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3349837478</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9959033912630115</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        220317810089563</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50163038961182183</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65426.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        20122305187</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        25683674.595941387</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        659651140750205</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.9983367666132601</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.66672175974962222</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.70748409268910473</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50053374140812579</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        219713274830427</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.999146259624704</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        9.4101812958619299e+23</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.995069950438136</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3421732630592</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950699474730247</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8182.5478515625</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2515590540.296875</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3208935.4367179158</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10297266637024.002</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9981813748315012</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.3331278962859721</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.4140893821604645</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487807389647</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        3421732632580.7539</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---640x480--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950699504391622</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---640x480--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10070266787</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50378782761890095</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        235809610.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        173695.98629214204</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30170295653.999996</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.66891549652664462</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.70889586105295754</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50253334181801401</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        40233638484</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50241603159627923</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10056377251</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9994022713305322</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        659651140750205</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50053374140812568</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65517.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        60390264790</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        44487237.371998996</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1979114288992584</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.99972533760585947</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.66674894961084696</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.70723055861803152</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50017506304317294</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        658894550698877</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950720844455843</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.8318736816543229e+24</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487813249277</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10297266620160</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487793408702</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8184.4794921875</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        7552639976.125</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5561895.8905984564</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30934685897855.996</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9986526055924976</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.333948302710561</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.4147023884889738</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0013828479964073</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10297266634099.107</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9996487813245094</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1280x720--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        22657955065.000004</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50355244156544543</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        255.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        530624466.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        260583.87791265981</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        67903957427.999992</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.66947115971927251</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.7093090028549377</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50311926153106601</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        90601148911</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50333498706877711</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        22659498745</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9989918413873182</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1482709467830083</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.49926350708770828</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65520.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        135906903969</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        66736829.715206839</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4453804440436514.5</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.99977111467154955</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.66675082179145451</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.70720439850278694</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50013806126168869</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1481659617679171</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9957369850784614</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6.3752211994030978e+24</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003021400457071</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        23181596342656</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003021369488159</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8186.0244140625</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        16984735692.875</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8340685.4474389581</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        69567033733120.016</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9990291609432234</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.3334577962934724</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.4143376841015531</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003510846697448</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        23181596328586.238</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0003021400448309</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---1920x1080--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        82154407.000000015</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.49012002941516958</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        253.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1987907.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        15955.914671368733</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        254591213.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.99215686274509807</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.67234909402809051</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.7099785987184023</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50406961063814615</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC4--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        339535659.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC4--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.50799604434877432</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8UC4--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        85293479.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9822857260123403</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--8SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5565548588686.999</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.4962127254724607</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        65359.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        513038317.</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4117439.4479245236</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        16953307607325.006</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.99740572876131184</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.67707527217801911</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.71658820097080211</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.51349864977057069</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16UC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5519312023183</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.019326771007266</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--16SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32SC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.3765786277490947e+22</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32SC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950645589785427</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32SC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        86417215253.999985</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950645537973593</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8177.4794921875</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L1->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        63532969.756835938</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L1->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        511076.27419202315</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        261198958042.00003</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9971720555104253</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L1-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.3316545244094513</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L1-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.4143125146030457</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.0002798889627909</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--32FC3--NORM_INF-NORM_L2-NORM_RELATIVE->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--64FC1--NORM_INF-NORM_L2->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        86417215447.745041</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--64FC1--NORM_INF-NORM_L2->
+<Size_MatType_NormType_norm2_mask--norm2_mask---127x61--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+  <n>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>1</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.9950645589556342</data></val></n></Size_MatType_NormType_norm2_mask--norm2_mask---127x61--64FC1--NORM_INF-NORM_L2-NORM_RELATIVE->
+<sortFixture_sort--sort---640x480--16SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32768.</min>
+    <max>32767.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>32551.</val></last>
+    <rng1>
+      <x>106</x>
+      <y>372</y>
+      <val>-22300.</val></rng1>
+    <rng2>
+      <x>324</x>
+      <y>35</y>
+      <val>619.</val></rng2></b></sortFixture_sort--sort---640x480--16SC1--0->
+<sortFixture_sort--sort---640x480--16SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32768.</min>
+    <max>32767.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>-32742.</val></last>
+    <rng1>
+      <x>49</x>
+      <y>474</y>
+      <val>27168.</val></rng1>
+    <rng2>
+      <x>369</x>
+      <y>133</y>
+      <val>-7619.</val></rng2></b></sortFixture_sort--sort---640x480--16SC1--16->
+<sortFixture_sort--sort---640x480--32SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2147466857.</min>
+    <max>2147386923.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>2120847639.</val></last>
+    <rng1>
+      <x>158</x>
+      <y>419</y>
+      <val>-1127682958.</val></rng1>
+    <rng2>
+      <x>426</x>
+      <y>213</y>
+      <val>730163274.</val></rng2></b></sortFixture_sort--sort---640x480--32SC1--0->
+<sortFixture_sort--sort---640x480--32SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2147466857.</min>
+    <max>2147386923.</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>-2141201436.</val></last>
+    <rng1>
+      <x>292</x>
+      <y>265</y>
+      <val>256565502.</val></rng1>
+    <rng2>
+      <x>107</x>
+      <y>380</y>
+      <val>1464085114.</val></rng2></b></sortFixture_sort--sort---640x480--32SC1--16->
+<sortFixture_sort--sort---640x480--64FC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4094.9679808205346</min>
+    <max>4094.8155578397214</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>4044.2082482394394</val></last>
+    <rng1>
+      <x>237</x>
+      <y>461</y>
+      <val>-886.5548984441748</val></rng1>
+    <rng2>
+      <x>28</x>
+      <y>339</y>
+      <val>-3722.2522400830794</val></rng2></b></sortFixture_sort--sort---640x480--64FC1--0->
+<sortFixture_sort--sort---640x480--64FC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4094.9679808205346</min>
+    <max>4094.8155578397214</max>
+    <last>
+      <x>639</x>
+      <y>479</y>
+      <val>-4083.0205568046877</val></last>
+    <rng1>
+      <x>225</x>
+      <y>402</y>
+      <val>1004.6609866215584</val></rng1>
+    <rng2>
+      <x>262</x>
+      <y>346</y>
+      <val>553.57780393165649</val></rng2></b></sortFixture_sort--sort---640x480--64FC1--16->
+<sortFixture_sort--sort---1280x720--16SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32768.</min>
+    <max>32767.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>32714.</val></last>
+    <rng1>
+      <x>965</x>
+      <y>337</y>
+      <val>15234.</val></rng1>
+    <rng2>
+      <x>1108</x>
+      <y>375</y>
+      <val>24728.</val></rng2></b></sortFixture_sort--sort---1280x720--16SC1--0->
+<sortFixture_sort--sort---1280x720--16SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32768.</min>
+    <max>32767.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>-32680.</val></last>
+    <rng1>
+      <x>131</x>
+      <y>651</y>
+      <val>26933.</val></rng1>
+    <rng2>
+      <x>902</x>
+      <y>515</y>
+      <val>-12799.</val></rng2></b></sortFixture_sort--sort---1280x720--16SC1--16->
+<sortFixture_sort--sort---1280x720--32SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2147479470.</min>
+    <max>2147473056.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>2146925983.</val></last>
+    <rng1>
+      <x>429</x>
+      <y>441</y>
+      <val>-660086116.</val></rng1>
+    <rng2>
+      <x>239</x>
+      <y>22</y>
+      <val>-1363160588.</val></rng2></b></sortFixture_sort--sort---1280x720--32SC1--0->
+<sortFixture_sort--sort---1280x720--32SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2147479470.</min>
+    <max>2147473056.</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>-2146560310.</val></last>
+    <rng1>
+      <x>1031</x>
+      <y>209</y>
+      <val>-1347680941.</val></rng1>
+    <rng2>
+      <x>608</x>
+      <y>634</y>
+      <val>111966736.</val></rng2></b></sortFixture_sort--sort---1280x720--32SC1--16->
+<sortFixture_sort--sort---1280x720--64FC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4094.9920315075342</min>
+    <max>4094.9798024340043</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>4093.9365998943886</val></last>
+    <rng1>
+      <x>820</x>
+      <y>114</y>
+      <val>1084.3902801326328</val></rng1>
+    <rng2>
+      <x>507</x>
+      <y>521</y>
+      <val>-792.55124072760259</val></rng2></b></sortFixture_sort--sort---1280x720--64FC1--0->
+<sortFixture_sort--sort---1280x720--64FC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4094.9920315075342</min>
+    <max>4094.9798024340043</max>
+    <last>
+      <x>1279</x>
+      <y>719</y>
+      <val>-4093.2393007006349</val></last>
+    <rng1>
+      <x>347</x>
+      <y>33</y>
+      <val>1839.18635881825</val></rng1>
+    <rng2>
+      <x>459</x>
+      <y>372</y>
+      <val>1252.0449737518115</val></rng2></b></sortFixture_sort--sort---1280x720--64FC1--16->
+<sortFixture_sort--sort---1920x1080--16SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32768.</min>
+    <max>32767.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>32759.</val></last>
+    <rng1>
+      <x>1312</x>
+      <y>412</y>
+      <val>11777.</val></rng1>
+    <rng2>
+      <x>1391</x>
+      <y>1079</y>
+      <val>14502.</val></rng2></b></sortFixture_sort--sort---1920x1080--16SC1--0->
+<sortFixture_sort--sort---1920x1080--16SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32768.</min>
+    <max>32767.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>-32688.</val></last>
+    <rng1>
+      <x>194</x>
+      <y>485</y>
+      <val>25974.</val></rng1>
+    <rng2>
+      <x>1812</x>
+      <y>183</y>
+      <val>-28734.</val></rng2></b></sortFixture_sort--sort---1920x1080--16SC1--16->
+<sortFixture_sort--sort---1920x1080--32SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2147482346.</min>
+    <max>2147482367.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>2145482091.</val></last>
+    <rng1>
+      <x>1694</x>
+      <y>900</y>
+      <val>1611459221.</val></rng1>
+    <rng2>
+      <x>1292</x>
+      <y>383</y>
+      <val>801409935.</val></rng2></b></sortFixture_sort--sort---1920x1080--32SC1--0->
+<sortFixture_sort--sort---1920x1080--32SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2147482346.</min>
+    <max>2147482367.</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>-2146411041.</val></last>
+    <rng1>
+      <x>831</x>
+      <y>285</y>
+      <val>243008337.</val></rng1>
+    <rng2>
+      <x>897</x>
+      <y>427</y>
+      <val>165999217.</val></rng2></b></sortFixture_sort--sort---1920x1080--32SC1--16->
+<sortFixture_sort--sort---1920x1080--64FC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4094.9975165536976</min>
+    <max>4094.9975574546829</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>4091.1832656385282</val></last>
+    <rng1>
+      <x>231</x>
+      <y>106</y>
+      <val>-3095.5465689280286</val></rng1>
+    <rng2>
+      <x>69</x>
+      <y>171</y>
+      <val>-3725.642968406024</val></rng2></b></sortFixture_sort--sort---1920x1080--64FC1--0->
+<sortFixture_sort--sort---1920x1080--64FC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4094.9975165536976</min>
+    <max>4094.9975574546829</max>
+    <last>
+      <x>1919</x>
+      <y>1079</y>
+      <val>-4092.9546629143269</val></last>
+    <rng1>
+      <x>1182</x>
+      <y>977</y>
+      <val>-817.12591726239475</val></rng1>
+    <rng2>
+      <x>334</x>
+      <y>697</y>
+      <val>2650.3378748656532</val></rng2></b></sortFixture_sort--sort---1920x1080--64FC1--16->
+<sortFixture_sort--sort---127x61--16SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32760.</min>
+    <max>32761.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>32730.</val></last>
+    <rng1>
+      <x>120</x>
+      <y>32</y>
+      <val>29799.</val></rng1>
+    <rng2>
+      <x>25</x>
+      <y>17</y>
+      <val>-19588.</val></rng2></b></sortFixture_sort--sort---127x61--16SC1--0->
+<sortFixture_sort--sort---127x61--16SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>3</type>
+    <min>-32760.</min>
+    <max>32761.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>-32257.</val></last>
+    <rng1>
+      <x>82</x>
+      <y>46</y>
+      <val>-10360.</val></rng1>
+    <rng2>
+      <x>15</x>
+      <y>23</y>
+      <val>27613.</val></rng2></b></sortFixture_sort--sort---127x61--16SC1--16->
+<sortFixture_sort--sort---127x61--32SC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2146910016.</min>
+    <max>2146033862.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>2098940365.</val></last>
+    <rng1>
+      <x>42</x>
+      <y>44</y>
+      <val>-775518313.</val></rng1>
+    <rng2>
+      <x>24</x>
+      <y>11</y>
+      <val>-1366979339.</val></rng2></b></sortFixture_sort--sort---127x61--32SC1--0->
+<sortFixture_sort--sort---127x61--32SC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>4</type>
+    <min>-2146910016.</min>
+    <max>2146033862.</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>-2142890040.</val></last>
+    <rng1>
+      <x>126</x>
+      <y>57</y>
+      <val>-2139240464.</val></rng1>
+    <rng2>
+      <x>9</x>
+      <y>11</y>
+      <val>2002573240.</val></rng2></b></sortFixture_sort--sort---127x61--32SC1--16->
+<sortFixture_sort--sort---127x61--64FC1--0->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4093.9061497929674</min>
+    <max>4092.2354290802841</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>4002.4336406755101</val></last>
+    <rng1>
+      <x>110</x>
+      <y>4</y>
+      <val>3081.4110611083966</val></rng1>
+    <rng2>
+      <x>33</x>
+      <y>12</y>
+      <val>-2514.7517598017807</val></rng2></b></sortFixture_sort--sort---127x61--64FC1--0->
+<sortFixture_sort--sort---127x61--64FC1--16->
+  <b>
+    <kind>65536</kind>
+    <type>6</type>
+    <min>-4093.9061497929674</min>
+    <max>4092.2354290802841</max>
+    <last>
+      <x>126</x>
+      <y>60</y>
+      <val>-4086.2405259034704</val></last>
+    <rng1>
+      <x>99</x>
+      <y>52</y>
+      <val>-3114.3799636915001</val></rng1>
+    <rng2>
+      <x>117</x>
+      <y>50</y>
+      <val>-3041.9528385026765</val></rng2></b></sortFixture_sort--sort---127x61--64FC1--16->
+<Size_MatType_sum--sum---640x480--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        39128559. 39069808. 39211441. 0.</data></val></s></Size_MatType_sum--sum---640x480--8UC3->
+<Size_MatType_sum--sum---640x480--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10068442665 0. 0. 0.</data></val></s></Size_MatType_sum--sum---640x480--16UC1->
+<Size_MatType_sum--sum---640x480--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10045220153 10054342208 10075047453 0.</data></val></s></Size_MatType_sum--sum---640x480--16UC3->
+<Size_MatType_sum--sum---640x480--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        10058531253 10071743123 10049456814 10068589294</data></val></s></Size_MatType_sum--sum---640x480--16UC4->
+<Size_MatType_sum--sum---640x480--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2139381.6680135089 -1225300.2582177501 -866929.71529836021 0.</data></val></s></Size_MatType_sum--sum---640x480--32FC3->
+<Size_MatType_sum--sum---640x480--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -1433239.5317338482 -353686.86125228601 668608.27948878706
+        836821.72237149812</data></val></s></Size_MatType_sum--sum---640x480--32FC4->
+<Size_MatType_sum--sum---640x480--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -6013399. 0. 0. 0.</data></val></s></Size_MatType_sum--sum---640x480--16SC1->
+<Size_MatType_sum--sum---640x480--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -1317575. 23008832. -13957603. 0.</data></val></s></Size_MatType_sum--sum---640x480--16SC3->
+<Size_MatType_sum--sum---640x480--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        5636533. -8480109. 10652334. -12289298.</data></val></s></Size_MatType_sum--sum---640x480--16SC4->
+<Size_MatType_sum--sum---1280x720--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        117442015. 117362033. 117486009. 0.</data></val></s></Size_MatType_sum--sum---1280x720--8UC3->
+<Size_MatType_sum--sum---1280x720--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30174609814 0. 0. 0.</data></val></s></Size_MatType_sum--sum---1280x720--16UC1->
+<Size_MatType_sum--sum---1280x720--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30185042695 30164831939 30200542909 0.</data></val></s></Size_MatType_sum--sum---1280x720--16UC3->
+<Size_MatType_sum--sum---1280x720--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30200129999 30209176453 30175569476 30184726481</data></val></s></Size_MatType_sum--sum---1280x720--16UC4->
+<Size_MatType_sum--sum---1280x720--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2125674.8712771125 -675388.71001079865 -1422921.3160522422 0.</data></val></s></Size_MatType_sum--sum---1280x720--32FC3->
+<Size_MatType_sum--sum---1280x720--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        30749.739691727795 -2392784.514141859 786782.51561408956
+        1231434.6964513222</data></val></s></Size_MatType_sum--sum---1280x720--32FC4->
+<Size_MatType_sum--sum---1280x720--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        7733654. 0. 0. 0.</data></val></s></Size_MatType_sum--sum---1280x720--16SC1->
+<Size_MatType_sum--sum---1280x720--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4115705. 28888771. -22169923. 0.</data></val></s></Size_MatType_sum--sum---1280x720--16SC3->
+<Size_MatType_sum--sum---1280x720--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -13211185. -14912635. 1615428. 2318289.</data></val></s></Size_MatType_sum--sum---1280x720--16SC4->
+<Size_MatType_sum--sum---1920x1080--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        264390286. 264218844. 264468011. 0.</data></val></s></Size_MatType_sum--sum---1920x1080--8UC3->
+<Size_MatType_sum--sum---1920x1080--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        67898573558 0. 0. 0.</data></val></s></Size_MatType_sum--sum---1920x1080--16UC1->
+<Size_MatType_sum--sum---1920x1080--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        67917092740 67898109315 67941203903 0.</data></val></s></Size_MatType_sum--sum---1920x1080--16UC3->
+<Size_MatType_sum--sum---1920x1080--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        67938029849 67965912167 67864113176 67922654261</data></val></s></Size_MatType_sum--sum---1920x1080--16UC4->
+<Size_MatType_sum--sum---1920x1080--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2921783.0967199397 -5542530.707355354 799699.74405662809 0.</data></val></s></Size_MatType_sum--sum---1920x1080--32FC3->
+<Size_MatType_sum--sum---1920x1080--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -51772.112359011546 -591481.57526209531 4731770.6394521315
+        2140298.6360571496</data></val></s></Size_MatType_sum--sum---1920x1080--32FC4->
+<Size_MatType_sum--sum---1920x1080--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        19596022. 0. 0. 0.</data></val></s></Size_MatType_sum--sum---1920x1080--16SC1->
+<Size_MatType_sum--sum---1920x1080--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8427396. 23981443. -14385217. 0.</data></val></s></Size_MatType_sum--sum---1920x1080--16SC3->
+<Size_MatType_sum--sum---1920x1080--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -13692647. -8420249. 23867416. -691147.</data></val></s></Size_MatType_sum--sum---1920x1080--16SC4->
+<Size_MatType_sum--sum---127x61--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        988380. 979265. 989617. 0.</data></val></s></Size_MatType_sum--sum---127x61--8UC3->
+<Size_MatType_sum--sum---127x61--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        252678737. 0. 0. 0.</data></val></s></Size_MatType_sum--sum---127x61--16UC1->
+<Size_MatType_sum--sum---127x61--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        253165564. 253225426. 253635338. 0.</data></val></s></Size_MatType_sum--sum---127x61--16UC3->
+<Size_MatType_sum--sum---127x61--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        254468060. 253922984. 252368116. 251749420.</data></val></s></Size_MatType_sum--sum---127x61--16UC4->
+<Size_MatType_sum--sum---127x61--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        115921.46214058995 29371.149702386931 -317777.6196167469 0.</data></val></s></Size_MatType_sum--sum---127x61--32FC3->
+<Size_MatType_sum--sum---127x61--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -254631.20547059178 -123869.48537361622 224319.12892609835
+        -282056.58986966126</data></val></s></Size_MatType_sum--sum---127x61--32FC4->
+<Size_MatType_sum--sum---127x61--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        561745. 0. 0. 0.</data></val></s></Size_MatType_sum--sum---127x61--16SC1->
+<Size_MatType_sum--sum---127x61--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1572860. -2037294. -1103094. 0.</data></val></s></Size_MatType_sum--sum---127x61--16SC3->
+<Size_MatType_sum--sum---127x61--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -139300. 298664. -731916. -302036.</data></val></s></Size_MatType_sum--sum---127x61--16SC4->
+<Size_MatType_mean--mean---640x480--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.37161132812501 127.18036458333334 127.64140950520834 0.</data></val></s></Size_MatType_mean--mean---640x480--8UC3->
+<Size_MatType_mean--mean---640x480--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32774.878466796879 0. 0. 0.</data></val></s></Size_MatType_mean--mean---640x480--16UC1->
+<Size_MatType_mean--mean---640x480--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32699.284352213544 32728.978541666667 32796.37842773438 0.</data></val></s></Size_MatType_mean--mean---640x480--16UC3->
+<Size_MatType_mean--mean---640x480--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32742.614755859377 32785.622145182293 32713.075566406253
+        32775.355774739583</data></val></s></Size_MatType_mean--mean---640x480--16UC4->
+<Size_MatType_mean--mean---640x480--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6.9641330338981415 -3.9886076113859055 -2.8220368336535167 0.</data></val></s></Size_MatType_mean--mean---640x480--32FC3->
+<Size_MatType_mean--mean---640x480--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4.6654932673627876 -1.1513244181389519 2.176459243127562
+        2.7240290441780539</data></val></s></Size_MatType_mean--mean---640x480--32FC4->
+<Size_MatType_mean--mean---640x480--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -19.574866536458334 0. 0. 0.</data></val></s></Size_MatType_mean--mean---640x480--16SC1->
+<Size_MatType_mean--mean---640x480--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4.288981119791667 74.898541666666674 -45.434905598958338 0.</data></val></s></Size_MatType_mean--mean---640x480--16SC3->
+<Size_MatType_mean--mean---640x480--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18.348089192708336 -27.604521484375002 34.675566406249999
+        -40.004225260416668</data></val></s></Size_MatType_mean--mean---640x480--16SC4->
+<Size_MatType_mean--mean---1280x720--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.43274197048611 127.34595594618055 127.48047851562499 0.</data></val></s></Size_MatType_mean--mean---1280x720--8UC3->
+<Size_MatType_mean--mean---1280x720--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32741.54710720486 0. 0. 0.</data></val></s></Size_MatType_mean--mean---1280x720--16UC1->
+<Size_MatType_mean--mean---1280x720--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32752.867507595485 32730.937433810763 32769.686316189232 0.</data></val></s></Size_MatType_mean--mean---1280x720--16UC3->
+<Size_MatType_mean--mean---1280x720--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32769.238280164929 32779.0543109809 32742.588407118055
+        32752.52439344618</data></val></s></Size_MatType_mean--mean---1280x720--16UC4->
+<Size_MatType_mean--mean---1280x720--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.3065048516461726 -0.73284365235546733 -1.5439684418969641 0.</data></val></s></Size_MatType_mean--mean---1280x720--32FC3->
+<Size_MatType_mean--mean---1280x720--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.033365602964114359 -2.5963373634351767 0.85371366711598262
+        1.3361921619480492</data></val></s></Size_MatType_mean--mean---1280x720--32FC4->
+<Size_MatType_mean--mean---1280x720--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        8.3915516493055549 0. 0. 0.</data></val></s></Size_MatType_mean--mean---1280x720--16SC1->
+<Size_MatType_mean--mean---1280x720--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4.4658257378472221 31.346322699652777 -24.055906032986112 0.</data></val></s></Size_MatType_mean--mean---1280x720--16SC3->
+<Size_MatType_mean--mean---1280x720--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -14.335053168402778 -16.181244574652776 1.7528515625000001
+        2.5155045572916666</data></val></s></Size_MatType_mean--mean---1280x720--16SC4->
+<Size_MatType_mean--mean---1920x1080--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.50303144290123 127.42035300925926 127.54051456404321 0.</data></val></s></Size_MatType_mean--mean---1920x1080--8UC3->
+<Size_MatType_mean--mean---1920x1080--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32744.296661844135 0. 0. 0.</data></val></s></Size_MatType_mean--mean---1920x1080--16UC1->
+<Size_MatType_mean--mean---1920x1080--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32753.227594521606 32744.072779224538 32764.855277295526 0.</data></val></s></Size_MatType_mean--mean---1920x1080--16UC3->
+<Size_MatType_mean--mean---1920x1080--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32763.324579957563 32776.770913869601 32727.678036265432
+        32755.909655189043</data></val></s></Size_MatType_mean--mean---1920x1080--16UC4->
+<Size_MatType_mean--mean---1920x1080--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.409038916242255 -2.6729025401983768 0.38565766978039551 0.</data></val></s></Size_MatType_mean--mean---1920x1080--32FC3->
+<Size_MatType_mean--mean---1920x1080--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -0.024967260975603561 -0.28524381523056297 2.2819109951061591
+        1.0321656230985483</data></val></s></Size_MatType_mean--mean---1920x1080--32FC4->
+<Size_MatType_mean--mean---1920x1080--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        9.4502420910493825 0. 0. 0.</data></val></s></Size_MatType_mean--mean---1920x1080--16SC1->
+<Size_MatType_mean--mean---1920x1080--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        4.0641377314814813 11.565124903549384 -6.9373152970679017 0.</data></val></s></Size_MatType_mean--mean---1920x1080--16SC3->
+<Size_MatType_mean--mean---1920x1080--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -6.6033212770061729 -4.0606910686728392 11.510135030864198
+        -0.33330777391975308</data></val></s></Size_MatType_mean--mean---1920x1080--16SC4->
+<Size_MatType_mean--mean---127x61--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.58228991867819 126.40570543436168 127.74196463147024 0.</data></val></s></Size_MatType_mean--mean---127x61--8UC3->
+<Size_MatType_mean--mean---127x61--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32616.333677552597 0. 0. 0.</data></val></s></Size_MatType_mean--mean---127x61--16UC1->
+<Size_MatType_mean--mean---127x61--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32679.174390086482 32686.901510262032 32739.813863431002 0.</data></val></s></Size_MatType_mean--mean---127x61--16UC3->
+<Size_MatType_mean--mean---127x61--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32847.303472311862 32776.94384923196 32576.238027623593
+        32496.375371111393</data></val></s></Size_MatType_mean--mean---127x61--16UC4->
+<Size_MatType_mean--mean---127x61--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        14.963400302128559 3.7912933654817254 -41.019442315315203 0.</data></val></s></Size_MatType_mean--mean---127x61--32FC3->
+<Size_MatType_mean--mean---127x61--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -32.868362652716115 -15.989348828400182 28.955612356537799
+        -36.408492302783173</data></val></s></Size_MatType_mean--mean---127x61--32FC4->
+<Size_MatType_mean--mean---127x61--16SC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        72.511294694720533 0. 0. 0.</data></val></s></Size_MatType_mean--mean---127x61--16SC1->
+<Size_MatType_mean--mean---127x61--16SC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        203.02826900735766 -262.9784432683619 -142.38982832064022 0.</data></val></s></Size_MatType_mean--mean---127x61--16SC3->
+<Size_MatType_mean--mean---127x61--16SC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -17.981153995094875 38.552213760165223 -94.477346069446227
+        -38.987479024138374</data></val></s></Size_MatType_mean--mean---127x61--16SC4->
+<Size_MatType_mean_mask--mean_mask---640x480--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.37161132812501 127.18036458333334 127.64140950520834 0.</data></val></s></Size_MatType_mean_mask--mean_mask---640x480--8UC3->
+<Size_MatType_mean_mask--mean_mask---640x480--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32774.878466796879 0. 0. 0.</data></val></s></Size_MatType_mean_mask--mean_mask---640x480--16UC1->
+<Size_MatType_mean_mask--mean_mask---640x480--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32699.284352213544 32728.978541666667 32796.37842773438 0.</data></val></s></Size_MatType_mean_mask--mean_mask---640x480--16UC3->
+<Size_MatType_mean_mask--mean_mask---640x480--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32742.614755859377 32785.622145182293 32713.075566406253
+        32775.355774739583</data></val></s></Size_MatType_mean_mask--mean_mask---640x480--16UC4->
+<Size_MatType_mean_mask--mean_mask---640x480--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6.9641330338981415 -3.9886076113859055 -2.8220368336535167 0.</data></val></s></Size_MatType_mean_mask--mean_mask---640x480--32FC3->
+<Size_MatType_mean_mask--mean_mask---640x480--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4.6654932673627876 -1.1513244181389519 2.176459243127562
+        2.7240290441780539</data></val></s></Size_MatType_mean_mask--mean_mask---640x480--32FC4->
+<Size_MatType_mean_mask--mean_mask---1280x720--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.43274197048611 127.34595594618055 127.48047851562499 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1280x720--8UC3->
+<Size_MatType_mean_mask--mean_mask---1280x720--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32741.54710720486 0. 0. 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1280x720--16UC1->
+<Size_MatType_mean_mask--mean_mask---1280x720--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32752.867507595485 32730.937433810763 32769.686316189232 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1280x720--16UC3->
+<Size_MatType_mean_mask--mean_mask---1280x720--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32769.238280164929 32779.0543109809 32742.588407118055
+        32752.52439344618</data></val></s></Size_MatType_mean_mask--mean_mask---1280x720--16UC4->
+<Size_MatType_mean_mask--mean_mask---1280x720--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.3065048516461726 -0.73284365235546733 -1.5439684418969641 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1280x720--32FC3->
+<Size_MatType_mean_mask--mean_mask---1280x720--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.033365602964114359 -2.5963373634351767 0.85371366711598262
+        1.3361921619480492</data></val></s></Size_MatType_mean_mask--mean_mask---1280x720--32FC4->
+<Size_MatType_mean_mask--mean_mask---1920x1080--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.50303144290123 127.42035300925926 127.54051456404321 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1920x1080--8UC3->
+<Size_MatType_mean_mask--mean_mask---1920x1080--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32744.296661844135 0. 0. 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1920x1080--16UC1->
+<Size_MatType_mean_mask--mean_mask---1920x1080--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32753.227594521606 32744.072779224538 32764.855277295526 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1920x1080--16UC3->
+<Size_MatType_mean_mask--mean_mask---1920x1080--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32763.324579957563 32776.770913869601 32727.678036265432
+        32755.909655189043</data></val></s></Size_MatType_mean_mask--mean_mask---1920x1080--16UC4->
+<Size_MatType_mean_mask--mean_mask---1920x1080--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.409038916242255 -2.6729025401983768 0.38565766978039551 0.</data></val></s></Size_MatType_mean_mask--mean_mask---1920x1080--32FC3->
+<Size_MatType_mean_mask--mean_mask---1920x1080--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -0.024967260975603561 -0.28524381523056297 2.2819109951061591
+        1.0321656230985483</data></val></s></Size_MatType_mean_mask--mean_mask---1920x1080--32FC4->
+<Size_MatType_mean_mask--mean_mask---127x61--8UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.58228991867819 126.40570543436168 127.74196463147024 0.</data></val></s></Size_MatType_mean_mask--mean_mask---127x61--8UC3->
+<Size_MatType_mean_mask--mean_mask---127x61--16UC1->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32616.333677552597 0. 0. 0.</data></val></s></Size_MatType_mean_mask--mean_mask---127x61--16UC1->
+<Size_MatType_mean_mask--mean_mask---127x61--16UC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32679.174390086482 32686.901510262032 32739.813863431002 0.</data></val></s></Size_MatType_mean_mask--mean_mask---127x61--16UC3->
+<Size_MatType_mean_mask--mean_mask---127x61--16UC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32847.303472311862 32776.94384923196 32576.238027623593
+        32496.375371111393</data></val></s></Size_MatType_mean_mask--mean_mask---127x61--16UC4->
+<Size_MatType_mean_mask--mean_mask---127x61--32FC3->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        14.963400302128559 3.7912933654817254 -41.019442315315203 0.</data></val></s></Size_MatType_mean_mask--mean_mask---127x61--32FC3->
+<Size_MatType_mean_mask--mean_mask---127x61--32FC4->
+  <s>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -32.868362652716115 -15.989348828400182 28.955612356537799
+        -36.408492302783173</data></val></s></Size_MatType_mean_mask--mean_mask---127x61--32FC4->
+<Size_MatType_meanStdDev--meanStdDev---640x480--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.37161132812501 127.18036458333334 127.64140950520834 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.888606161678254 73.875865238322774 73.995393187598197 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---640x480--8UC3->
+<Size_MatType_meanStdDev--meanStdDev---640x480--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32774.878466796879 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18929.070432170705 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---640x480--16UC1->
+<Size_MatType_meanStdDev--meanStdDev---640x480--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32699.284352213544 32728.978541666667 32796.37842773438 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18928.512524930346 18928.375151442317 18935.093393979572 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---640x480--16UC3->
+<Size_MatType_meanStdDev--meanStdDev---640x480--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32742.614755859377 32785.622145182293 32713.075566406253
+        32775.355774739583</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18894.719652774125 18945.801301868923 18927.890695346541
+        18933.389847056747</data></val></dev></Size_MatType_meanStdDev--meanStdDev---640x480--16UC4->
+<Size_MatType_meanStdDev--meanStdDev---640x480--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6.9641330338981415 -3.9886076113859055 -2.8220368336535167 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2364.6096921845538 2362.5954599213414 2362.7018424942189 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---640x480--32FC3->
+<Size_MatType_meanStdDev--meanStdDev---640x480--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4.6654932673627876 -1.1513244181389519 2.176459243127562
+        2.7240290441780539</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2366.5376969701724 2362.7212796080398 2358.6051314091674
+        2365.331254491512</data></val></dev></Size_MatType_meanStdDev--meanStdDev---640x480--32FC4->
+<Size_MatType_meanStdDev--meanStdDev---1280x720--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.43274197048611 127.34595594618055 127.48047851562499 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.898025903496617 73.869347910984487 73.908795020111413 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1280x720--8UC3->
+<Size_MatType_meanStdDev--meanStdDev---1280x720--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32741.54710720486 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18930.704201569144 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1280x720--16UC1->
+<Size_MatType_meanStdDev--meanStdDev---1280x720--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32752.867507595485 32730.937433810763 32769.686316189232 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18917.096583975796 18926.62327400341 18908.733940878064 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1280x720--16UC3->
+<Size_MatType_meanStdDev--meanStdDev---1280x720--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32769.238280164929 32779.0543109809 32742.588407118055
+        32752.52439344618</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18910.103038224985 18924.214549284381 18912.967220293125
+        18918.907874123786</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1280x720--16UC4->
+<Size_MatType_meanStdDev--meanStdDev---1280x720--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.3065048516461726 -0.73284365235546733 -1.5439684418969641 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2363.641372790521 2363.0618965898957 2363.7014426218411 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1280x720--32FC3->
+<Size_MatType_meanStdDev--meanStdDev---1280x720--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.033365602964114359 -2.5963373634351767 0.85371366711598262
+        1.3361921619480492</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2365.087038727313 2363.5132049629342 2360.9131417416129
+        2364.0721188888283</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1280x720--32FC4->
+<Size_MatType_meanStdDev--meanStdDev---1920x1080--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.50303144290123 127.42035300925926 127.54051456404321 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.894419445485553 73.857770787253131 73.898336359298057 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1920x1080--8UC3->
+<Size_MatType_meanStdDev--meanStdDev---1920x1080--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32744.296661844135 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18918.293539270871 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1920x1080--16UC1->
+<Size_MatType_meanStdDev--meanStdDev---1920x1080--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32753.227594521606 32744.072779224538 32764.855277295526 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18922.185706357777 18922.511656275688 18913.185986017706 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1920x1080--16UC3->
+<Size_MatType_meanStdDev--meanStdDev---1920x1080--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32763.324579957563 32776.770913869601 32727.678036265432
+        32755.909655189043</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18914.486099444533 18921.044909355936 18921.917789838197
+        18920.03421259407</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1920x1080--16UC4->
+<Size_MatType_meanStdDev--meanStdDev---1920x1080--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.409038916242255 -2.6729025401983768 0.38565766978039551 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2363.9906004164086 2363.3474593975252 2364.5881885848098 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1920x1080--32FC3->
+<Size_MatType_meanStdDev--meanStdDev---1920x1080--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -0.024967260975603561 -0.28524381523056297 2.2819109951061591
+        1.0321656230985483</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2363.7802590581118 2364.4545893757327 2363.996972820667
+        2364.2413548681143</data></val></dev></Size_MatType_meanStdDev--meanStdDev---1920x1080--32FC4->
+<Size_MatType_meanStdDev--meanStdDev---127x61--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.58228991867819 126.40570543436168 127.74196463147024 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.542191227628649 73.420779075329705 73.995376607597294 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---127x61--8UC3->
+<Size_MatType_meanStdDev--meanStdDev---127x61--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32616.333677552597 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18877.37016659541 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---127x61--16UC1->
+<Size_MatType_meanStdDev--meanStdDev---127x61--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32679.174390086482 32686.901510262032 32739.813863431002 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        19115.628373493633 18861.156524141006 19052.382612397581 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---127x61--16UC3->
+<Size_MatType_meanStdDev--meanStdDev---127x61--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32847.303472311862 32776.94384923196 32576.238027623593
+        32496.375371111393</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18924.290217922753 19069.33926598875 19004.740806129954
+        18957.49714676911</data></val></dev></Size_MatType_meanStdDev--meanStdDev---127x61--16UC4->
+<Size_MatType_meanStdDev--meanStdDev---127x61--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        14.963400302128559 3.7912933654817254 -41.019442315315203 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2382.9216269537869 2350.9249359371402 2347.0201557906871 0.</data></val></dev></Size_MatType_meanStdDev--meanStdDev---127x61--32FC3->
+<Size_MatType_meanStdDev--meanStdDev---127x61--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -32.868362652716115 -15.989348828400182 28.955612356537799
+        -36.408492302783173</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2362.1744761030495 2366.5113726531122 2365.9175090566496
+        2362.8184236300408</data></val></dev></Size_MatType_meanStdDev--meanStdDev---127x61--32FC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.37161132812501 127.18036458333334 127.64140950520834 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.888606161678254 73.875865238322774 73.995393187598197 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--8UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32774.878466796879 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18929.070432170705 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--16UC1->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32699.284352213544 32728.978541666667 32796.37842773438 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18928.512524930346 18928.375151442317 18935.093393979572 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--16UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32742.614755859377 32785.622145182293 32713.075566406253
+        32775.355774739583</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18894.719652774125 18945.801301868923 18927.890695346541
+        18933.389847056747</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--16UC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        6.9641330338981415 -3.9886076113859055 -2.8220368336535167 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2364.6096921846151 2362.5954599214861 2362.701842494329 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--32FC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -4.6654932673627876 -1.1513244181389519 2.176459243127562
+        2.7240290441780539</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2366.5376969702879 2362.7212796081158 2358.6051314092701
+        2365.3312544915707</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---640x480--32FC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.43274197048611 127.34595594618055 127.48047851562499 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.898025903496617 73.869347910984487 73.908795020111413 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--8UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32741.54710720486 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18930.704201569144 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--16UC1->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32752.867507595485 32730.937433810763 32769.686316189232 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18917.096583975796 18926.62327400341 18908.733940878064 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--16UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32769.238280164929 32779.0543109809 32742.588407118055
+        32752.52439344618</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18910.103038224985 18924.214549284381 18912.967220293125
+        18918.907874123786</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--16UC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2.3065048516461726 -0.73284365235546733 -1.5439684418969641 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2363.6413727906597 2363.0618965900867 2363.7014426219639 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--32FC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        0.033365602964114359 -2.5963373634351767 0.85371366711598262
+        1.3361921619480492</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2365.087038727424 2363.5132049630106 2360.913141741798
+        2364.0721188889875</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1280x720--32FC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.50303144290123 127.42035300925926 127.54051456404321 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.894419445485553 73.857770787253131 73.898336359298057 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--8UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32744.296661844135 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18918.293539270871 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--16UC1->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32753.227594521606 32744.072779224538 32764.855277295526 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18922.185706357777 18922.511656275688 18913.185986017706 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--16UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32763.324579957563 32776.770913869601 32727.678036265432
+        32755.909655189043</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18914.486099444533 18921.044909355936 18921.917789838197
+        18920.03421259407</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--16UC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        1.409038916242255 -2.6729025401983768 0.38565766978039551 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2363.9906004166423 2363.3474593977653 2364.5881885851286 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--32FC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -0.024967260975603561 -0.28524381523056297 2.2819109951061591
+        1.0321656230985483</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2363.7802590583196 2364.4545893759419 2363.9969728208562
+        2364.2413548682966</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---1920x1080--32FC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--8UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        127.58228991867819 126.40570543436168 127.74196463147024 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        73.542191227628649 73.420779075329705 73.995376607597294 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--8UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--16UC1->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32616.333677552597 0. 0. 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18877.37016659541 0. 0. 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--16UC1->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--16UC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32679.174390086482 32686.901510262032 32739.813863431002 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        19115.628373493633 18861.156524141006 19052.382612397581 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--16UC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--16UC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        32847.303472311862 32776.94384923196 32576.238027623593
+        32496.375371111393</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        18924.290217922753 19069.33926598875 19004.740806129954
+        18957.49714676911</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--16UC4->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--32FC3->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        14.963400302128559 3.7912933654817254 -41.019442315315203 0.</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2382.9216269538038 2350.9249359371574 2347.0201557907062 0.</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--32FC3->
+<Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--32FC4->
+  <mean>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        -32.868362652716115 -15.989348828400182 28.955612356537799
+        -36.408492302783173</data></val></mean>
+  <dev>
+    <kind>131072</kind>
+    <type>6</type>
+    <val type_id="opencv-matrix">
+      <rows>4</rows>
+      <cols>1</cols>
+      <dt>d</dt>
+      <data>
+        2362.1744761030632 2366.5113726531254 2365.9175090566587
+        2362.8184236300544</data></val></dev></Size_MatType_meanStdDev_mask--meanStdDev_mask---127x61--32FC4->
 </opencv_storage>


### PR DESCRIPTION
Core tests are extended in https://github.com/opencv/opencv/pull/29922
So, we need a newer baseline for extended tests